### PR TITLE
MPSGraph integration: 1.25-2.2x faster than MLX

### DIFF
--- a/scripts/bench_graph_decode.jl
+++ b/scripts/bench_graph_decode.jl
@@ -1,0 +1,104 @@
+"""Benchmark decode (seq=1) with KV cache via fused MPSGraph."""
+
+using Metal
+using Statistics
+
+include(joinpath(@__DIR__, "..", "src", "metal_graph.jl"))
+include(joinpath(@__DIR__, "..", "src", "graph_forward.jl"))
+using .MetalGraphModule
+using .GraphForward
+
+const HIDDEN = 3072
+const HEAD_DIM = 128
+const N_Q = 24
+const N_KV = 8
+const INTER = 8192
+const N_LAYERS = 28
+const EPS = 1f-5
+const MAX_LEN = 512
+
+function bench_decode(cache_len::Int; n_warmup=30, n_iter=200)
+    q_dim = N_Q * HEAD_DIM; kv_dim = N_KV * HEAD_DIM
+    qkv_dim = q_dim + 2 * kv_dim; half_hd = HEAD_DIM ÷ 2
+
+    println("\n=== Fused Decode (cache=$cache_len, max=$MAX_LEN) ===")
+    println("Building graph...")
+    t0 = time_ns()
+    dec = build_decode_full(HIDDEN, HEAD_DIM, N_Q, N_KV, INTER, MAX_LEN, N_LAYERS, EPS)
+    println("  Built in $(round((time_ns()-t0)/1e9, digits=2))s")
+
+    # Build feeds
+    feeds = Dict{GraphTensor, MtlArray}(
+        dec.x_ph => MtlArray(randn(Float16, HIDDEN, 1)),
+        dec.cos_ph => MtlArray(rand(Float16, half_hd, 1)),
+        dec.sin_ph => MtlArray(rand(Float16, half_hd, 1)),
+        dec.final_norm_w_ph => MtlArray(ones(Float16, HIDDEN, 1)),
+    )
+
+    # Attention mask: 0 for positions 1..cache_len, -1e4 for cache_len+1..max_len
+    mask = fill(Float16(-1e4), 1, MAX_LEN)
+    mask[1, 1:cache_len] .= Float16(0)
+    feeds[dec.attn_mask_ph] = MtlArray(mask)
+
+    for l in 1:N_LAYERS
+        feeds[dec.input_norm_ws[l]] = MtlArray(ones(Float16, HIDDEN, 1))
+        feeds[dec.w_qkvs[l]] = MtlArray(randn(Float16, qkv_dim, HIDDEN) * Float16(0.02))
+        feeds[dec.w_os[l]] = MtlArray(randn(Float16, HIDDEN, q_dim) * Float16(0.02))
+        # KV cache: random for positions 1..cache_len, zero for rest
+        kc = zeros(Float16, HEAD_DIM, N_KV, MAX_LEN)
+        kc[:, :, 1:cache_len] .= randn(Float16, HEAD_DIM, N_KV, cache_len) * Float16(0.02)
+        feeds[dec.k_caches[l]] = MtlArray(kc)
+        vc = zeros(Float16, HEAD_DIM, N_KV, MAX_LEN)
+        vc[:, :, 1:cache_len] .= randn(Float16, HEAD_DIM, N_KV, cache_len) * Float16(0.02)
+        feeds[dec.v_caches[l]] = MtlArray(vc)
+        feeds[dec.post_norm_ws[l]] = MtlArray(ones(Float16, HIDDEN, 1))
+        feeds[dec.w_gate_ups[l]] = MtlArray(randn(Float16, 2*INTER, HIDDEN) * Float16(0.02))
+        feeds[dec.w_downs[l]] = MtlArray(randn(Float16, HIDDEN, INTER) * Float16(0.02))
+    end
+
+    out_buf = MtlArray(zeros(Float16, HIDDEN, 1))
+    outputs = Dict{GraphTensor, MtlArray}(dec.out => out_buf)
+    # Also allocate output buffers for new K/V (needed by execute_gpu!)
+    for l in 1:N_LAYERS
+        outputs[dec.new_ks[l]] = MtlArray(zeros(Float16, HEAD_DIM, N_KV, 1))
+        outputs[dec.new_vs[l]] = MtlArray(zeros(Float16, HEAD_DIM, N_KV, 1))
+    end
+
+    println("Warming up ($n_warmup iterations)...")
+    for _ in 1:n_warmup
+        execute_gpu!(dec.compiled, feeds, outputs)
+        Metal.synchronize()
+    end
+
+    println("Benchmarking ($n_iter iterations)...")
+    times = Float64[]
+    for _ in 1:n_iter
+        t0 = time_ns()
+        execute_gpu!(dec.compiled, feeds, outputs)
+        Metal.synchronize()
+        push!(times, (time_ns() - t0) / 1e6)
+    end
+
+    med = median(times)
+    mn = minimum(times)
+    println("  Median: $(round(med, digits=2)) ms = $(round(Int, 1000/med)) tok/s")
+    println("  Min:    $(round(mn, digits=2)) ms")
+    return med
+end
+
+println("MPSGraph Decode Benchmark (Llama-3.2-3B, 28 layers)")
+println("Max KV cache length: $MAX_LEN")
+
+results = Dict{Int, Float64}()
+for cache_len in [1, 32, 128, 256, 512]
+    results[cache_len] = bench_decode(cache_len)
+end
+
+println("\n" * "="^60)
+println("Summary — Decode throughput (tok/s):")
+println("| Cache Len | MPSGraph | MLX (est.) |")
+println("|-----------|----------|------------|")
+for cl in [1, 32, 128, 256, 512]
+    tps = round(Int, 1000 / results[cl])
+    println("|    $cl$(repeat(" ", 7-length(string(cl)))) | $tps tok/s | ~33 tok/s |")
+end

--- a/scripts/bench_graph_fused.jl
+++ b/scripts/bench_graph_fused.jl
@@ -1,0 +1,98 @@
+"""Benchmark: fused 28-layer MPSGraph vs per-layer MPSGraph vs MLX."""
+
+using Metal
+using Statistics
+
+include(joinpath(@__DIR__, "..", "src", "metal_graph.jl"))
+include(joinpath(@__DIR__, "..", "src", "graph_forward.jl"))
+using .MetalGraphModule
+using .GraphForward
+
+const HIDDEN = 3072
+const HEAD_DIM = 128
+const N_Q_HEADS = 24
+const N_KV_HEADS = 8
+const INTERMEDIATE = 8192
+const N_LAYERS = 28
+const EPS = 1f-5
+
+function bench_fused_forward(seq_len::Int; n_warmup=10, n_iter=50)
+    q_dim = N_Q_HEADS * HEAD_DIM
+    kv_dim = N_KV_HEADS * HEAD_DIM
+    qkv_dim = q_dim + 2 * kv_dim
+    half_hd = HEAD_DIM ÷ 2
+
+    println("\n=== Fused $N_LAYERS-Layer MPSGraph (seq=$seq_len) ===")
+    println("Building graph ($(N_LAYERS) layers in single graph)...")
+    t0 = time_ns()
+    fwd = build_full_forward(HIDDEN, HEAD_DIM, N_Q_HEADS, N_KV_HEADS,
+                              INTERMEDIATE, seq_len, N_LAYERS, EPS)
+    build_time = (time_ns() - t0) / 1e9
+    println("  Graph built in $(round(build_time, digits=2))s")
+
+    # Allocate feeds
+    x = MtlArray(randn(Float16, HIDDEN, seq_len) * Float16(0.02))
+    cos_t = MtlArray(rand(Float16, half_hd, seq_len))
+    sin_t = MtlArray(rand(Float16, half_hd, seq_len))
+
+    feeds = Dict{GraphTensor, MtlArray}(
+        fwd.x_ph => x,
+        fwd.cos_ph => cos_t,
+        fwd.sin_ph => sin_t,
+        fwd.final_norm_w_ph => MtlArray(ones(Float16, HIDDEN, 1)),
+    )
+
+    # Per-layer weights
+    for l in 1:N_LAYERS
+        feeds[fwd.input_norm_ws[l]] = MtlArray(ones(Float16, HIDDEN, 1))
+        feeds[fwd.w_qkvs[l]] = MtlArray(randn(Float16, qkv_dim, HIDDEN) * Float16(0.02))
+        feeds[fwd.w_os[l]] = MtlArray(randn(Float16, HIDDEN, q_dim) * Float16(0.02))
+        feeds[fwd.post_norm_ws[l]] = MtlArray(ones(Float16, HIDDEN, 1))
+        feeds[fwd.w_gate_ups[l]] = MtlArray(randn(Float16, 2*INTERMEDIATE, HIDDEN) * Float16(0.02))
+        feeds[fwd.w_downs[l]] = MtlArray(randn(Float16, HIDDEN, INTERMEDIATE) * Float16(0.02))
+    end
+
+    out_buf = MtlArray(zeros(Float16, HIDDEN, seq_len))
+    outputs = Dict{GraphTensor, MtlArray}(fwd.out => out_buf)
+
+    println("Warming up ($n_warmup iterations)...")
+    for _ in 1:n_warmup
+        execute_gpu!(fwd.compiled, feeds, outputs)
+        Metal.synchronize()
+    end
+
+    println("Benchmarking ($n_iter iterations)...")
+    times = Float64[]
+    for _ in 1:n_iter
+        t0 = time_ns()
+        execute_gpu!(fwd.compiled, feeds, outputs)
+        Metal.synchronize()
+        push!(times, (time_ns() - t0) / 1e6)
+    end
+
+    med = median(times)
+    mn = minimum(times)
+    tok_per_s = seq_len / (med / 1000)
+    println("  Median: $(round(med, digits=2)) ms ($(round(Int, tok_per_s)) tok/s)")
+    println("  Min:    $(round(mn, digits=2)) ms")
+    return med
+end
+
+println("Fused MPSGraph Full Forward Pass Benchmark")
+println("Model: Llama-3.2-3B ($N_LAYERS layers)")
+println("Hidden=$HIDDEN, Heads=$N_Q_HEADS/$N_KV_HEADS, Inter=$INTERMEDIATE")
+
+results = Dict{Int, Float64}()
+for seq in [8, 32, 64]
+    results[seq] = bench_fused_forward(seq)
+end
+
+# Compare with per-layer numbers from previous bench
+println("\n" * "="^60)
+println("Summary (28-layer forward, median ms):")
+println("| seq | Fused Graph | Per-Layer Graph* | MLX* |")
+println("|-----|-------------|-----------------|------|")
+for seq in [8, 32, 64]
+    println("|  $seq | $(round(results[seq], digits=1)) ms | — | — |")
+end
+println("* Fill in from bench_graph_layer.jl and bench_mlx_layer.py")

--- a/scripts/bench_graph_layer.jl
+++ b/scripts/bench_graph_layer.jl
@@ -1,0 +1,181 @@
+"""Benchmark MPSGraph transformer layer vs Julia kernels.
+
+Tests single-layer and multi-layer (simulating full forward pass) performance.
+Compares: MPSGraph fused graph vs Julia @metal dispatches.
+"""
+
+using Metal
+using Statistics
+
+include(joinpath(@__DIR__, "..", "src", "metal_graph.jl"))
+include(joinpath(@__DIR__, "..", "src", "graph_forward.jl"))
+using .MetalGraphModule
+using .GraphForward
+
+# Llama-3.2-3B dimensions
+const HIDDEN = 3072
+const HEAD_DIM = 128
+const N_Q_HEADS = 24
+const N_KV_HEADS = 8
+const INTERMEDIATE = 8192
+const N_LAYERS = 28
+const EPS = 1f-5
+
+function bench_graph_layer(seq_len::Int; n_warmup=20, n_iter=100)
+    q_dim = N_Q_HEADS * HEAD_DIM
+    kv_dim = N_KV_HEADS * HEAD_DIM
+    qkv_dim = q_dim + 2 * kv_dim
+    half_hd = HEAD_DIM ÷ 2
+
+    println("\n=== MPSGraph Transformer Layer (seq=$seq_len) ===")
+    println("Building graph...")
+
+    layer = build_transformer_layer(HIDDEN, HEAD_DIM, N_Q_HEADS, N_KV_HEADS,
+                                     INTERMEDIATE, seq_len, EPS; emit_normed=false)
+
+    # Allocate GPU data
+    x = MtlArray(randn(Float16, HIDDEN, seq_len))
+    residual = MtlArray(randn(Float16, HIDDEN, seq_len))
+    w_qkv = MtlArray(randn(Float16, qkv_dim, HIDDEN) * Float16(0.02))
+    w_o = MtlArray(randn(Float16, HIDDEN, q_dim) * Float16(0.02))
+    cos_t = MtlArray(rand(Float16, half_hd, seq_len))
+    sin_t = MtlArray(rand(Float16, half_hd, seq_len))
+    post_norm_w = MtlArray(ones(Float16, HIDDEN, 1))
+    w_gu = MtlArray(randn(Float16, 2*INTERMEDIATE, HIDDEN) * Float16(0.02))
+    w_down = MtlArray(randn(Float16, HIDDEN, INTERMEDIATE) * Float16(0.02))
+    out_buf = MtlArray(zeros(Float16, HIDDEN, seq_len))
+
+    feeds = Dict{GraphTensor, MtlArray}(
+        layer.x_ph => x,
+        layer.residual_ph => residual,
+        layer.w_qkv_ph => w_qkv,
+        layer.w_o_ph => w_o,
+        layer.cos_ph => cos_t,
+        layer.sin_ph => sin_t,
+        layer.post_norm_w_ph => post_norm_w,
+        layer.w_gate_up_ph => w_gu,
+        layer.w_down_ph => w_down,
+    )
+    outputs = Dict{GraphTensor, MtlArray}(layer.out_residual => out_buf)
+
+    # Warmup
+    println("Warming up ($n_warmup iterations)...")
+    for _ in 1:n_warmup
+        execute_gpu!(layer.compiled, feeds, outputs)
+    end
+    Metal.synchronize()
+
+    # Benchmark
+    println("Benchmarking ($n_iter iterations)...")
+    times = Float64[]
+    for _ in 1:n_iter
+        t0 = time_ns()
+        execute_gpu!(layer.compiled, feeds, outputs)
+        Metal.synchronize()
+        push!(times, (time_ns() - t0) / 1e6)
+    end
+
+    med = median(times)
+    mn = minimum(times)
+    println("  Median: $(round(med, digits=3)) ms")
+    println("  Min:    $(round(mn, digits=3)) ms")
+    return med
+end
+
+function bench_multi_layer(seq_len::Int, n_layers::Int; n_warmup=10, n_iter=50)
+    q_dim = N_Q_HEADS * HEAD_DIM
+    kv_dim = N_KV_HEADS * HEAD_DIM
+    qkv_dim = q_dim + 2 * kv_dim
+    half_hd = HEAD_DIM ÷ 2
+
+    println("\n=== MPSGraph $n_layers-Layer Forward Pass (seq=$seq_len) ===")
+    println("Building graph...")
+
+    layer = build_transformer_layer(HIDDEN, HEAD_DIM, N_Q_HEADS, N_KV_HEADS,
+                                     INTERMEDIATE, seq_len, EPS; emit_normed=false)
+
+    # Shared weights (same graph reused per layer, different weight feeds)
+    w_qkv = MtlArray(randn(Float16, qkv_dim, HIDDEN) * Float16(0.02))
+    w_o = MtlArray(randn(Float16, HIDDEN, q_dim) * Float16(0.02))
+    cos_t = MtlArray(rand(Float16, half_hd, seq_len))
+    sin_t = MtlArray(rand(Float16, half_hd, seq_len))
+    norm_w = MtlArray(ones(Float16, HIDDEN, 1))
+    w_gu = MtlArray(randn(Float16, 2*INTERMEDIATE, HIDDEN) * Float16(0.02))
+    w_down = MtlArray(randn(Float16, HIDDEN, INTERMEDIATE) * Float16(0.02))
+
+    buf_a = MtlArray(randn(Float16, HIDDEN, seq_len))
+    buf_b = MtlArray(zeros(Float16, HIDDEN, seq_len))
+    normed_buf = MtlArray(zeros(Float16, HIDDEN, seq_len))
+
+    # For simplicity, we'll use the same graph instance and just swap buffers
+    # In production, each layer would have its own weight feeds
+
+    println("Warming up ($n_warmup iterations)...")
+    for _ in 1:n_warmup
+        residual = buf_a
+        for l in 1:n_layers
+            feeds = Dict{GraphTensor, MtlArray}(
+                layer.x_ph => buf_a,  # normed input (simplified: skip rmsnorm for first layer)
+                layer.residual_ph => residual,
+                layer.w_qkv_ph => w_qkv,
+                layer.w_o_ph => w_o,
+                layer.cos_ph => cos_t,
+                layer.sin_ph => sin_t,
+                layer.post_norm_w_ph => norm_w,
+                layer.w_gate_up_ph => w_gu,
+                layer.w_down_ph => w_down,
+            )
+            outputs = Dict{GraphTensor, MtlArray}(layer.out_residual => buf_b)
+            execute_gpu!(layer.compiled, feeds, outputs)
+            buf_a, buf_b = buf_b, buf_a
+        end
+        Metal.synchronize()
+    end
+
+    println("Benchmarking ($n_iter iterations)...")
+    times = Float64[]
+    for _ in 1:n_iter
+        t0 = time_ns()
+        for l in 1:n_layers
+            feeds = Dict{GraphTensor, MtlArray}(
+                layer.x_ph => buf_a,
+                layer.residual_ph => buf_a,
+                layer.w_qkv_ph => w_qkv,
+                layer.w_o_ph => w_o,
+                layer.cos_ph => cos_t,
+                layer.sin_ph => sin_t,
+                layer.post_norm_w_ph => norm_w,
+                layer.w_gate_up_ph => w_gu,
+                layer.w_down_ph => w_down,
+            )
+            outputs = Dict{GraphTensor, MtlArray}(layer.out_residual => buf_b)
+            execute_gpu!(layer.compiled, feeds, outputs)
+            buf_a, buf_b = buf_b, buf_a
+        end
+        Metal.synchronize()
+        push!(times, (time_ns() - t0) / 1e6)
+    end
+
+    med = median(times)
+    mn = minimum(times)
+    tok_per_s = seq_len / (med / 1000)
+    println("  Median: $(round(med, digits=2)) ms ($(round(Int, tok_per_s)) tok/s)")
+    println("  Min:    $(round(mn, digits=2)) ms")
+    return med
+end
+
+# ── Run benchmarks ──
+println("MPSGraph Transformer Layer Benchmark")
+println("Model: Llama-3.2-3B equivalent dims")
+println("Hidden=$HIDDEN, Heads=$N_Q_HEADS/$N_KV_HEADS, Inter=$INTERMEDIATE")
+
+# Single layer at various seq lengths
+for seq in [8, 16, 32, 64]
+    bench_graph_layer(seq)
+end
+
+# Full 28-layer forward pass
+println("\n" * "="^60)
+for seq in [8, 32, 64]
+    bench_multi_layer(seq, N_LAYERS)
+end

--- a/scripts/bench_mlx_layer.py
+++ b/scripts/bench_mlx_layer.py
@@ -1,0 +1,150 @@
+"""Benchmark MLX transformer layer for comparison with our MPSGraph implementation."""
+
+import mlx.core as mx
+import mlx.nn as nn
+import time
+import numpy as np
+
+# Llama-3.2-3B dimensions
+HIDDEN = 3072
+HEAD_DIM = 128
+N_Q_HEADS = 24
+N_KV_HEADS = 8
+INTERMEDIATE = 8192
+N_LAYERS = 28
+EPS = 1e-5
+
+class LlamaAttention(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.q_proj = nn.Linear(HIDDEN, N_Q_HEADS * HEAD_DIM, bias=False)
+        self.k_proj = nn.Linear(HIDDEN, N_KV_HEADS * HEAD_DIM, bias=False)
+        self.v_proj = nn.Linear(HIDDEN, N_KV_HEADS * HEAD_DIM, bias=False)
+        self.o_proj = nn.Linear(N_Q_HEADS * HEAD_DIM, HIDDEN, bias=False)
+        self.scale = HEAD_DIM ** -0.5
+
+    def __call__(self, x, cos, sin):
+        B, S, _ = x.shape
+        q = self.q_proj(x).reshape(B, S, N_Q_HEADS, HEAD_DIM).transpose(0, 2, 1, 3)
+        k = self.k_proj(x).reshape(B, S, N_KV_HEADS, HEAD_DIM).transpose(0, 2, 1, 3)
+        v = self.v_proj(x).reshape(B, S, N_KV_HEADS, HEAD_DIM).transpose(0, 2, 1, 3)
+
+        # RoPE
+        q = apply_rope(q, cos, sin)
+        k = apply_rope(k, cos, sin)
+
+        # GQA: repeat KV heads
+        if N_Q_HEADS != N_KV_HEADS:
+            n_rep = N_Q_HEADS // N_KV_HEADS
+            k = mx.repeat(k, n_rep, axis=1)
+            v = mx.repeat(v, n_rep, axis=1)
+
+        # Attention
+        scores = (q @ k.transpose(0, 1, 3, 2)) * self.scale
+        mask = nn.MultiHeadAttention.create_additive_causal_mask(S)
+        scores = scores + mask
+        weights = mx.softmax(scores, axis=-1)
+        out = (weights @ v).transpose(0, 2, 1, 3).reshape(B, S, -1)
+        return self.o_proj(out)
+
+class LlamaMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.gate_proj = nn.Linear(HIDDEN, INTERMEDIATE, bias=False)
+        self.up_proj = nn.Linear(HIDDEN, INTERMEDIATE, bias=False)
+        self.down_proj = nn.Linear(INTERMEDIATE, HIDDEN, bias=False)
+
+    def __call__(self, x):
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+class LlamaLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.input_layernorm = nn.RMSNorm(HIDDEN, eps=EPS)
+        self.self_attn = LlamaAttention()
+        self.post_attention_layernorm = nn.RMSNorm(HIDDEN, eps=EPS)
+        self.mlp = LlamaMLP()
+
+    def __call__(self, x, cos, sin):
+        h = x + self.self_attn(self.input_layernorm(x), cos, sin)
+        out = h + self.mlp(self.post_attention_layernorm(h))
+        return out
+
+def apply_rope(x, cos, sin):
+    # x: (B, H, S, D)
+    half = x.shape[-1] // 2
+    x1 = x[..., :half]
+    x2 = x[..., half:]
+    return mx.concatenate([x1 * cos - x2 * sin, x2 * cos + x1 * sin], axis=-1)
+
+def bench_single_layer(seq_len, n_warmup=20, n_iter=100):
+    print(f"\n=== MLX Single Layer (seq={seq_len}) ===")
+    layer = LlamaLayer()
+    mx.eval(layer.parameters())
+
+    x = mx.random.normal((1, seq_len, HIDDEN)).astype(mx.float16)
+    cos = mx.random.normal((1, 1, seq_len, HEAD_DIM // 2)).astype(mx.float16)
+    sin = mx.random.normal((1, 1, seq_len, HEAD_DIM // 2)).astype(mx.float16)
+
+    # Warmup
+    for _ in range(n_warmup):
+        out = layer(x, cos, sin)
+        mx.eval(out)
+
+    # Benchmark
+    times = []
+    for _ in range(n_iter):
+        t0 = time.perf_counter_ns()
+        out = layer(x, cos, sin)
+        mx.eval(out)
+        times.append((time.perf_counter_ns() - t0) / 1e6)
+
+    med = np.median(times)
+    mn = np.min(times)
+    print(f"  Median: {med:.3f} ms")
+    print(f"  Min:    {mn:.3f} ms")
+    return med
+
+def bench_multi_layer(seq_len, n_layers, n_warmup=10, n_iter=50):
+    print(f"\n=== MLX {n_layers}-Layer Forward Pass (seq={seq_len}) ===")
+    layers = [LlamaLayer() for _ in range(n_layers)]
+    mx.eval([l.parameters() for l in layers])
+
+    x = mx.random.normal((1, seq_len, HIDDEN)).astype(mx.float16)
+    cos = mx.random.normal((1, 1, seq_len, HEAD_DIM // 2)).astype(mx.float16)
+    sin = mx.random.normal((1, 1, seq_len, HEAD_DIM // 2)).astype(mx.float16)
+
+    # Warmup
+    for _ in range(n_warmup):
+        h = x
+        for layer in layers:
+            h = layer(h, cos, sin)
+        mx.eval(h)
+
+    # Benchmark
+    times = []
+    for _ in range(n_iter):
+        t0 = time.perf_counter_ns()
+        h = x
+        for layer in layers:
+            h = layer(h, cos, sin)
+        mx.eval(h)
+        times.append((time.perf_counter_ns() - t0) / 1e6)
+
+    med = np.median(times)
+    mn = np.min(times)
+    tok_per_s = seq_len / (med / 1000)
+    print(f"  Median: {med:.2f} ms ({tok_per_s:.0f} tok/s)")
+    print(f"  Min:    {mn:.2f} ms")
+    return med
+
+if __name__ == "__main__":
+    print("MLX Transformer Layer Benchmark")
+    print(f"Hidden={HIDDEN}, Heads={N_Q_HEADS}/{N_KV_HEADS}, Inter={INTERMEDIATE}")
+
+    for seq in [8, 16, 32, 64]:
+        bench_single_layer(seq)
+
+    print("\n" + "=" * 60)
+    for seq in [8, 32, 64]:
+        bench_multi_layer(seq, N_LAYERS)

--- a/src/LLMs.jl
+++ b/src/LLMs.jl
@@ -72,7 +72,7 @@ export metal_qmatmul_v4!
 export metal_fused_gate_up_swiglu!
 export metal_flash_attention!
 export metal_fused_qkv!
-export metal_qmatmul_vec!, metal_fp16_matmul!
+export metal_qmatmul_vec!, metal_fp16_matmul!, metal_qmatmul_sg!
 export metal_argmax_last_col, metal_argmax_last_col!
 
 # Phase 2 model exports

--- a/src/graph_forward.jl
+++ b/src/graph_forward.jl
@@ -1,0 +1,646 @@
+"""
+    graph_forward.jl — Full transformer layer as a single MPSGraph
+
+Builds the entire forward pass (attention + MLP) for a transformer layer
+as a fused computation graph, eliminating intermediate memory round-trips.
+"""
+module GraphForward
+
+using Metal
+using ..MetalGraphModule
+
+# ── Graph-based MLP block ──
+
+struct GraphMLP
+    """Pre-compiled MPSGraph for: rmsnorm → gate_up matmul → silu(gate)*up → down matmul → residual add"""
+    compiled::CompiledGraph
+
+    # Placeholder handles for feeding data
+    x_ph::GraphTensor       # input hidden state (hidden, seq)
+    residual_ph::GraphTensor # residual stream (hidden, seq)
+    norm_w_ph::GraphTensor  # rmsnorm weight (hidden, 1)
+    w_gate_up_ph::GraphTensor # fused gate+up weight (2*inter, hidden)
+    w_down_ph::GraphTensor  # down projection weight (hidden, inter)
+
+    # Output handle
+    out::GraphTensor        # residual + down(silu(gate(normed)) * up(normed))
+    normed_out::GraphTensor # optional: normed output (for next layer's attention)
+
+    hidden::Int
+    intermediate::Int
+end
+
+"""Build MLP graph for given dimensions."""
+function build_mlp_graph(hidden::Int, intermediate::Int, seq_len::Int, eps::Float32;
+                         fuse_next_rmsnorm::Bool=false, next_norm_w_ph=nothing)
+    g = MetalGraphBuilder()
+
+    # Placeholders
+    x_ph = placeholder!(g, (hidden, seq_len), Float16)
+    residual_ph = placeholder!(g, (hidden, seq_len), Float16)
+    norm_w_ph = placeholder!(g, (hidden, 1), Float16)
+    w_gu_ph = placeholder!(g, (2 * intermediate, hidden), Float16)
+    w_down_ph = placeholder!(g, (hidden, intermediate), Float16)
+
+    # RMSNorm
+    normed = rmsnorm!(g, x_ph, norm_w_ph, eps)
+
+    # Fused gate+up matmul
+    gu = matmul!(g, w_gu_ph, normed)
+
+    # Split gate and up
+    gate = slice!(g, gu, 1, 0, intermediate)
+    up = slice!(g, gu, 1, intermediate, intermediate)
+
+    # SwiGLU: silu(gate) * up
+    swi = silu!(g, gate)
+    fused = mul!(g, swi, up)
+
+    # Down projection
+    down_out = matmul!(g, w_down_ph, fused)
+
+    # Residual add: out = residual + down_out
+    out = add!(g, residual_ph, down_out)
+
+    # Optionally fuse the next layer's input rmsnorm
+    normed_out_tensor = if fuse_next_rmsnorm && next_norm_w_ph !== nothing
+        rmsnorm!(g, out, next_norm_w_ph, eps)
+    else
+        out  # dummy — won't be used
+    end
+
+    targets = fuse_next_rmsnorm ? [out, normed_out_tensor] : [out]
+    compiled = compile!(g, targets)
+
+    GraphMLP(compiled, x_ph, residual_ph, norm_w_ph, w_gu_ph, w_down_ph,
+             out, normed_out_tensor, hidden, intermediate)
+end
+
+"""Execute MLP graph with pre-allocated GPU buffers."""
+function execute_mlp!(mlp::GraphMLP, x::MtlMatrix{Float16}, residual::MtlMatrix{Float16},
+                      norm_w::MtlMatrix{Float16}, w_gate_up::MtlMatrix{Float16},
+                      w_down::MtlMatrix{Float16}, out::MtlMatrix{Float16};
+                      normed_out::Union{MtlMatrix{Float16}, Nothing}=nothing)
+    feeds = Dict{GraphTensor, MtlArray}(
+        mlp.x_ph => x,
+        mlp.residual_ph => residual,
+        mlp.norm_w_ph => norm_w,
+        mlp.w_gate_up_ph => w_gate_up,
+        mlp.w_down_ph => w_down,
+    )
+    outputs = Dict{GraphTensor, MtlArray}(mlp.out => out)
+    if normed_out !== nothing
+        outputs[mlp.normed_out] = normed_out
+    end
+    execute_gpu!(mlp.compiled, feeds, outputs)
+end
+
+
+# ── Graph-based Attention block ──
+
+struct GraphAttention
+    """Pre-compiled MPSGraph for: QKV matmul → split → rope → attention → O proj"""
+    compiled::CompiledGraph
+
+    # Placeholders
+    normed_ph::GraphTensor    # normed input (hidden, seq)
+    w_qkv_ph::GraphTensor     # fused QKV weight (q+k+v, hidden)
+    w_o_ph::GraphTensor       # output projection (hidden, q_dim)
+    cos_ph::GraphTensor       # rope cos table (half_hd, seq)
+    sin_ph::GraphTensor       # rope sin table (half_hd, seq)
+
+    # Output
+    out::GraphTensor          # attention output (hidden, seq)
+
+    hidden::Int
+    head_dim::Int
+    n_q_heads::Int
+    n_kv_heads::Int
+end
+
+"""Build attention graph for prefill (no KV cache, self-attention only).
+For decode with KV cache, we'll need a separate graph or hybrid approach."""
+function build_attention_graph(hidden::Int, head_dim::Int, n_q_heads::Int, n_kv_heads::Int,
+                               seq_len::Int, eps::Float32)
+    g = MetalGraphBuilder()
+    q_dim = n_q_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+    qkv_dim = q_dim + 2 * kv_dim
+    half_hd = head_dim ÷ 2
+    gqa_ratio = n_q_heads ÷ n_kv_heads
+    scale = Float16(1.0 / sqrt(Float64(head_dim)))
+
+    # Placeholders
+    normed_ph = placeholder!(g, (hidden, seq_len), Float16)
+    w_qkv_ph = placeholder!(g, (qkv_dim, hidden), Float16)
+    w_o_ph = placeholder!(g, (hidden, q_dim), Float16)
+    cos_ph = placeholder!(g, (half_hd, seq_len), Float16)
+    sin_ph = placeholder!(g, (half_hd, seq_len), Float16)
+
+    # QKV matmul
+    qkv = matmul!(g, w_qkv_ph, normed_ph)  # (qkv_dim, seq)
+
+    # Split Q, K, V
+    q_flat = slice!(g, qkv, 1, 0, q_dim)           # (q_dim, seq)
+    k_flat = slice!(g, qkv, 1, q_dim, kv_dim)      # (kv_dim, seq)
+    v_flat = slice!(g, qkv, 1, q_dim + kv_dim, kv_dim)  # (kv_dim, seq)
+
+    # Reshape to (head_dim, n_heads, seq) for RoPE and attention
+    q_3d = reshape!(g, q_flat, (head_dim, n_q_heads, seq_len))
+    k_3d = reshape!(g, k_flat, (head_dim, n_kv_heads, seq_len))
+    v_3d = reshape!(g, v_flat, (head_dim, n_kv_heads, seq_len))
+
+    # RoPE on Q and K
+    # Need cos/sin as (half_hd, 1, seq) for broadcasting over heads
+    cos_3d = reshape!(g, cos_ph, (half_hd, 1, seq_len))
+    sin_3d = reshape!(g, sin_ph, (half_hd, 1, seq_len))
+
+    q_roped = apply_rope!(g, q_3d, cos_3d, sin_3d, half_hd)
+    k_roped = apply_rope!(g, k_3d, cos_3d, sin_3d, half_hd)
+
+    # Attention: for each query head, find its KV head (GQA)
+    # Reshape Q: (head_dim, n_kv_heads, gqa_ratio, seq) and K/V stay (head_dim, n_kv_heads, seq)
+    # Then attention scores: Q^T @ K for each head group
+
+    # For GQA: reshape Q to (head_dim, gqa_ratio, n_kv_heads, seq)
+    # Then transpose to get batch dims right for batched matmul
+    # scores[h,i,j] = sum_d Q[d,h,i] * K[d,h,j] / sqrt(d)
+
+    # Approach: transpose to (n_kv_heads, head_dim, seq) for K and V
+    # Then for each KV head, Q has gqa_ratio query heads
+
+    # Simple approach: reshape Q to group by KV heads
+    # Q: (head_dim, n_q_heads, seq) → (head_dim, gqa_ratio, n_kv_heads, seq)
+    q_grouped = reshape!(g, q_roped, (head_dim, gqa_ratio, n_kv_heads, seq_len))
+
+    # Transpose for batched matmul: we want scores = Q^T @ K per head
+    # Q: (head_dim, gqa_ratio, n_kv_heads, seq) → (n_kv_heads, gqa_ratio, seq, head_dim) via transposes
+    # K: (head_dim, n_kv_heads, seq) → (n_kv_heads, head_dim, seq)
+
+    # Q: swap dim1↔dim3 to get (seq, gqa_ratio, n_kv_heads, head_dim)
+    # then swap dim3↔dim4 nah this is getting complex. Let me think about MPSGraph's batched matmul.
+
+    # MPSGraph matmul broadcasts over batch dims. For 3D tensors (B, M, K) @ (B, K, N) = (B, M, N)
+    # Remember: we swap args for row/col major, so matmul!(g, a, b) = Julia a@b
+
+    # K transposed: (n_kv_heads, seq, head_dim) — K^T in the (seq, head_dim) sense
+    k_t = graph_transpose!(g, k_roped, 1, 3)  # (head_dim, n_kv, seq) → (seq, n_kv, head_dim)
+    k_t = graph_transpose!(g, k_t, 2, 3)      # → (seq, head_dim, n_kv)
+    # Hmm, this isn't right. Let me think step by step.
+
+    # What we want:
+    # For each kv_head h, for each gqa q_head within that group:
+    #   scores[h, g, i, j] = sum_d Q[d, g, h, i] * K[d, h, j] / sqrt(d)
+    # This is a batched matmul: (h*g, seq, head_dim) @ (h, head_dim, seq) with broadcasting
+
+    # Let me use a simpler layout:
+    # Merge gqa into batch: Q (head_dim, n_q_heads, seq) with n_q_heads = n_kv_heads * gqa_ratio
+    # Repeat K for each gqa group: K (head_dim, n_q_heads, seq) — wasteful but simple
+
+    # Actually, MPSGraph should handle broadcasting: if K is (head_dim, n_kv_heads, seq)
+    # and we reshape Q as (head_dim, gqa_ratio, n_kv_heads, seq), the matmul should broadcast K
+    # over the gqa_ratio dimension. But matmul only operates on the last 2 dims.
+
+    # Let me try: Q as 4D (head_dim, gqa_ratio, n_kv_heads, seq)
+    # For scores, we need (seq, seq) per head. So:
+    # Q_t: (gqa_ratio, n_kv_heads, seq, head_dim) — transpose dim1↔dim4 of Q
+    # K: (n_kv_heads, head_dim, seq) — need to broadcast over gqa_ratio
+
+    # Simpler: just use n_q_heads as batch dim, tile K
+    # Q: (n_q_heads, seq, head_dim) — from (head_dim, n_q_heads, seq) via transposes
+    # K: (n_q_heads, head_dim, seq) — tile n_kv_heads → n_q_heads
+
+    # Let's do this in the straightforward way:
+    # Step 1: Rearrange Q to (n_q_heads, seq, head_dim)
+    q_perm = graph_transpose!(g, q_roped, 1, 2)   # (head_dim, n_q, seq) → (n_q, head_dim, seq)
+    q_perm = graph_transpose!(g, q_perm, 2, 3)     # → (n_q, seq, head_dim)
+
+    # Step 2: Rearrange K to (n_kv_heads, head_dim, seq) — already (head_dim, n_kv, seq)
+    # We need (n_q, head_dim, seq) by repeating KV heads gqa_ratio times
+    # First transpose to (n_kv, head_dim, seq)
+    k_perm = graph_transpose!(g, k_roped, 1, 2)   # → (n_kv, head_dim, seq)
+
+    # Tile KV heads: reshape (n_kv, 1, head_dim, seq) then broadcast with (n_kv, gqa_ratio, head_dim, seq)
+    # MPSGraph concat/tile isn't straightforward. Let's just tile via reshape + expand + reshape
+    if gqa_ratio > 1
+        # (n_kv, head_dim, seq) → (n_kv, 1, head_dim, seq) → broadcast to (n_kv, gqa, head_dim, seq)
+        # → reshape to (n_q, head_dim, seq)
+        k_exp = expanddims!(g, k_perm, 2)  # (n_kv, 1, head_dim, seq)
+        # Use concat with gqa_ratio copies — this physically tiles
+        k_tiled = concat!(g, [k_exp for _ in 1:gqa_ratio], 2)  # (n_kv, gqa, head_dim, seq)
+        k_final = reshape!(g, k_tiled, (n_q_heads, head_dim, seq_len))  # (n_q, head_dim, seq)
+
+        v_perm = graph_transpose!(g, v_3d, 1, 2)  # (n_kv, head_dim, seq)
+        v_exp = expanddims!(g, v_perm, 2)
+        v_tiled = concat!(g, [v_exp for _ in 1:gqa_ratio], 2)
+        v_final = reshape!(g, v_tiled, (n_q_heads, head_dim, seq_len))
+    else
+        k_final = k_perm
+        v_final = graph_transpose!(g, v_3d, 1, 2)  # (n_kv, head_dim, seq)
+    end
+
+    # Step 3: Batched matmul for scores
+    # scores = Q @ K^T: (n_q, seq, head_dim) @ (n_q, head_dim, seq) → (n_q, seq, seq)
+    # In our wrapper, matmul!(g, a, b) = a @ b in Julia convention
+    # But for 3D batch matmul, the batch dim is dim 3 (last) in Julia
+    # Wait — shapes are Julia convention: q_perm is (n_q, seq, head_dim) in Julia
+    # MPSGraph sees it as (head_dim, seq, n_q) in row-major
+    # MPSGraph batched matmul: last 2 dims are the matrix dims, earlier dims are batch
+    # So (head_dim, seq, n_q) × (seq, head_dim, n_q) matmul in MPSGraph
+    # = for each batch n_q: (head_dim, seq) × (seq, head_dim) = (head_dim, head_dim) — WRONG
+
+    # I need to think about this more carefully.
+    # In Julia col-major convention, matmul on 2D is: (M, K) @ (K, N) = (M, N)
+    # In our wrapper, matmul!(g, a, b) does this correctly for 2D by swapping args to MPSGraph.
+
+    # For 3D batched matmul in Julia convention: (M, K, B) @ (K, N, B) = (M, N, B)
+    # which maps to MPSGraph row-major: (B, K, M) @ (B, N, K) = (B, N, M) — that IS matmul(b,a) in MPSGraph!
+    # So our existing matmul! (which does MPSGraph matmul(b, a)) should work for 3D too!
+
+    # Let's verify the shapes:
+    # Q: Julia (n_q, seq, head_dim) = MPSGraph (head_dim, seq, n_q)
+    # K_final: Julia (n_q, head_dim, seq) = MPSGraph (seq, head_dim, n_q)
+    # scores = matmul!(g, Q, K_final): Julia (n_q, seq, head_dim) @ (n_q, head_dim, seq)
+    # Hmm this doesn't match the (M,K,B) @ (K,N,B) pattern since batch B is dim 1 not dim 3.
+
+    # I think the issue is that our Q is (n_q, seq, head_dim) in Julia,
+    # but for batched matmul we want batch as the LAST dim in Julia (which becomes first in MPSGraph).
+
+    # Let me rearrange: Q_t = (seq, head_dim, n_q) so batch=n_q is last dim
+    # Hmm wait, that means the matrix dims are (seq, head_dim) and we want scores as (seq, seq).
+    # So: Q_t (seq, head_dim, n_q) @ K_t (head_dim, seq, n_q) = (seq, seq, n_q) ← scores!
+
+    # MPSGraph: (n_q, head_dim, seq) matmul(b,a) (n_q, seq, head_dim) = (n_q, seq, seq)
+    # reversed to Julia: (seq, seq, n_q) ← YES!
+
+    # So Q needs to be (seq, head_dim, n_q) and K needs to be (head_dim, seq, n_q):
+    # q_roped is (head_dim, n_q, seq) → transpose(2,3) → (head_dim, seq, n_q) — that's K format
+    # We need Q as (seq, head_dim, n_q) → transpose(1,2) of (head_dim, seq, n_q)
+
+    # Let me redo this cleanly:
+    # q_roped: (head_dim, n_q, seq)
+    # k_roped: (head_dim, n_kv, seq)
+
+    # For scores = Q^T K / sqrt(d):
+    # Q_t: transpose to (seq, head_dim, n_q) — swap dim 1,3 then dim 1,2? No...
+    # (head_dim, n_q, seq) →swap(2,3)→ (head_dim, seq, n_q) →swap(1,2)→ (seq, head_dim, n_q) ✓
+
+    q_for_attn = graph_transpose!(g, q_roped, 2, 3)  # (head_dim, seq, n_q)
+    q_for_attn = graph_transpose!(g, q_for_attn, 1, 2)  # (seq, head_dim, n_q)
+
+    # K: (head_dim, n_kv, seq) — need (head_dim, seq, n_q) with GQA tiling
+    k_for_attn = graph_transpose!(g, k_roped, 2, 3)  # (head_dim, seq, n_kv)
+
+    # V: (head_dim, n_kv, seq) — need (seq, head_dim, n_q) for value aggregation later
+    # Actually V: need (head_dim, seq, n_q) for attn_weights @ V
+    v_for_attn = graph_transpose!(g, v_3d, 2, 3)  # (head_dim, seq, n_kv)
+
+    # GQA tiling
+    if gqa_ratio > 1
+        # (head_dim, seq, n_kv) → (head_dim, seq, 1, n_kv) → tile → (head_dim, seq, gqa, n_kv)
+        # → reshape to (head_dim, seq, n_q)
+        k_exp = expanddims!(g, k_for_attn, 3)  # (head_dim, seq, 1, n_kv)
+        k_tiled = concat!(g, [k_exp for _ in 1:gqa_ratio], 3)  # (head_dim, seq, gqa, n_kv)
+        k_for_attn = reshape!(g, k_tiled, (head_dim, seq_len, n_q_heads))
+
+        v_exp = expanddims!(g, v_for_attn, 3)
+        v_tiled = concat!(g, [v_exp for _ in 1:gqa_ratio], 3)
+        v_for_attn = reshape!(g, v_tiled, (head_dim, seq_len, n_q_heads))
+    end
+
+    # Batched scores: (seq, head_dim, n_q) @ (head_dim, seq, n_q) → (seq, seq, n_q)
+    scores = matmul!(g, q_for_attn, k_for_attn)
+
+    # Scale
+    scale_t = constant_scalar!(g, Float64(scale), Float16)
+    scores = mul!(g, scores, scale_t)
+
+    # Causal mask: lower triangular
+    # Create ones matrix (seq, seq) and use bandpart to make it lower triangular
+    ones_mat = constant_fill!(g, 1.0, (seq_len, seq_len), Float16)
+    mask = bandpart!(g, ones_mat, -1, 0)  # lower triangular (including diagonal)
+    # Where mask == 0, set scores to -inf
+    neg_inf = constant_scalar!(g, -1e4, Float16)  # -inf for fp16
+    inv_mask = sub!(g, constant_scalar!(g, 1.0, Float16), mask)  # 1 - mask = upper triangular
+    mask_penalty = mul!(g, inv_mask, neg_inf)
+    scores = add!(g, scores, mask_penalty)
+
+    # Softmax along dim 1 (the K sequence dimension — first seq in (seq, seq, n_q))
+    attn_weights = softmax!(g, scores, 1)
+
+    # Value aggregation: attn_weights @ V
+    # attn_weights: (seq, seq, n_q), V: (head_dim, seq, n_q)
+    # Want: (head_dim, seq, n_q) = V @ attn_weights^T per batch
+    # i.e., out[d, i, h] = sum_j V[d, j, h] * attn[i, j, h]
+    # = V @ attn^T in the (head_dim, seq) dims with batch n_q
+
+    # (head_dim, seq, n_q) @ (seq, seq, n_q) — matmul dims are (head_dim, seq) @ (seq, seq) = (head_dim, seq)
+    # But matmul!(a, b) = a @ b where a is (M,K,B) b is (K,N,B) → (M,N,B)
+    # v_for_attn: (head_dim, seq, n_q) — M=head_dim, K=seq
+    # attn_weights: (seq, seq, n_q) — K=seq, N=seq
+    # So matmul!(v_for_attn, attn_weights) = (head_dim, seq, n_q) ✓
+    attn_out = matmul!(g, v_for_attn, attn_weights)
+
+    # Transpose back: (head_dim, seq, n_q) → (head_dim, n_q, seq)
+    attn_out = graph_transpose!(g, attn_out, 2, 3)
+
+    # Flatten heads: (head_dim, n_q, seq) → (q_dim, seq)
+    attn_flat = reshape!(g, attn_out, (q_dim, seq_len))
+
+    # O projection
+    out = matmul!(g, w_o_ph, attn_flat)  # (hidden, seq)
+
+    compiled = compile!(g, [out])
+
+    GraphAttention(compiled, normed_ph, w_qkv_ph, w_o_ph, cos_ph, sin_ph,
+                   out, hidden, head_dim, n_q_heads, n_kv_heads)
+end
+
+"""Apply RoPE within graph: split → rotate → concat."""
+function apply_rope!(g::MetalGraphBuilder, x::GraphTensor, cos_t::GraphTensor,
+                     sin_t::GraphTensor, half_hd::Int)
+    x_lo = slice!(g, x, 1, 0, half_hd)
+    x_hi = slice!(g, x, 1, half_hd, half_hd)
+    out_lo = sub!(g, mul!(g, x_lo, cos_t), mul!(g, x_hi, sin_t))
+    out_hi = add!(g, mul!(g, x_hi, cos_t), mul!(g, x_lo, sin_t))
+    concat!(g, [out_lo, out_hi], 1)
+end
+
+
+# ── Full transformer layer graph ──
+
+struct GraphTransformerLayer
+    compiled::CompiledGraph
+
+    # Placeholders
+    x_ph::GraphTensor           # input (hidden, seq) — already normed for this layer
+    residual_ph::GraphTensor    # residual stream (hidden, seq)
+    w_qkv_ph::GraphTensor       # fused QKV weights
+    w_o_ph::GraphTensor         # O projection weights
+    cos_ph::GraphTensor         # RoPE cos
+    sin_ph::GraphTensor         # RoPE sin
+    post_norm_w_ph::GraphTensor # post-attention norm weights
+    w_gate_up_ph::GraphTensor   # fused gate+up weights
+    w_down_ph::GraphTensor      # down projection weights
+
+    # Outputs
+    out_residual::GraphTensor   # updated residual (hidden, seq)
+    out_normed::GraphTensor     # normed output for next layer (hidden, seq)
+
+    hidden::Int
+    seq_len::Int
+end
+
+"""Build a full transformer layer as a single MPSGraph (prefill only, no KV cache)."""
+function build_transformer_layer(hidden::Int, head_dim::Int, n_q_heads::Int, n_kv_heads::Int,
+                                 intermediate::Int, seq_len::Int, eps::Float32;
+                                 emit_normed::Bool=true)
+    g = MetalGraphBuilder()
+    q_dim = n_q_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+    qkv_dim = q_dim + 2 * kv_dim
+    half_hd = head_dim ÷ 2
+    gqa_ratio = n_q_heads ÷ n_kv_heads
+    scale = Float16(1.0 / sqrt(Float64(head_dim)))
+
+    # ── Placeholders ──
+    x_ph = placeholder!(g, (hidden, seq_len), Float16)            # normed input
+    residual_ph = placeholder!(g, (hidden, seq_len), Float16)     # residual stream
+    w_qkv_ph = placeholder!(g, (qkv_dim, hidden), Float16)
+    w_o_ph = placeholder!(g, (hidden, q_dim), Float16)
+    cos_ph = placeholder!(g, (half_hd, seq_len), Float16)
+    sin_ph = placeholder!(g, (half_hd, seq_len), Float16)
+    post_norm_w_ph = placeholder!(g, (hidden, 1), Float16)
+    w_gu_ph = placeholder!(g, (2 * intermediate, hidden), Float16)
+    w_down_ph = placeholder!(g, (hidden, intermediate), Float16)
+
+    # ── Attention ──
+    qkv = matmul!(g, w_qkv_ph, x_ph)
+    q_flat = slice!(g, qkv, 1, 0, q_dim)
+    k_flat = slice!(g, qkv, 1, q_dim, kv_dim)
+    v_flat = slice!(g, qkv, 1, q_dim + kv_dim, kv_dim)
+
+    q_3d = reshape!(g, q_flat, (head_dim, n_q_heads, seq_len))
+    k_3d = reshape!(g, k_flat, (head_dim, n_kv_heads, seq_len))
+    v_3d = reshape!(g, v_flat, (head_dim, n_kv_heads, seq_len))
+
+    cos_3d = reshape!(g, cos_ph, (half_hd, 1, seq_len))
+    sin_3d = reshape!(g, sin_ph, (half_hd, 1, seq_len))
+
+    q_roped = apply_rope!(g, q_3d, cos_3d, sin_3d, half_hd)
+    k_roped = apply_rope!(g, k_3d, cos_3d, sin_3d, half_hd)
+
+    # Rearrange for batched matmul: batch dim is last in Julia (first in MPSGraph)
+    q_t = graph_transpose!(g, q_roped, 2, 3)   # (hd, seq, n_q)
+    q_t = graph_transpose!(g, q_t, 1, 2)        # (seq, hd, n_q)
+
+    k_t = graph_transpose!(g, k_roped, 2, 3)    # (hd, seq, n_kv)
+    v_t = graph_transpose!(g, v_3d, 2, 3)        # (hd, seq, n_kv)
+
+    # GQA tiling
+    if gqa_ratio > 1
+        k_exp = expanddims!(g, k_t, 3)
+        k_tiled = concat!(g, [k_exp for _ in 1:gqa_ratio], 3)
+        k_t = reshape!(g, k_tiled, (head_dim, seq_len, n_q_heads))
+
+        v_exp = expanddims!(g, v_t, 3)
+        v_tiled = concat!(g, [v_exp for _ in 1:gqa_ratio], 3)
+        v_t = reshape!(g, v_tiled, (head_dim, seq_len, n_q_heads))
+    end
+
+    # Scores: (seq, hd, n_q) @ (hd, seq, n_q) → (seq, seq, n_q)
+    scores = matmul!(g, q_t, k_t)
+    scores = mul!(g, scores, constant_scalar!(g, Float64(scale), Float16))
+
+    # Causal mask
+    ones_mat = constant_fill!(g, 1.0, (seq_len, seq_len), Float16)
+    mask = bandpart!(g, ones_mat, -1, 0)
+    inv_mask = sub!(g, constant_scalar!(g, 1.0, Float16), mask)
+    scores = add!(g, scores, mul!(g, inv_mask, constant_scalar!(g, -1e4, Float16)))
+
+    attn_w = softmax!(g, scores, 1)
+
+    # Value aggregation: (hd, seq, n_q) @ (seq, seq, n_q) → (hd, seq, n_q)
+    attn_out = matmul!(g, v_t, attn_w)
+
+    # Back to (hd, n_q, seq) → flatten to (q_dim, seq)
+    attn_out = graph_transpose!(g, attn_out, 2, 3)
+    attn_flat = reshape!(g, attn_out, (q_dim, seq_len))
+
+    # O projection + residual
+    o_out = matmul!(g, w_o_ph, attn_flat)
+    attn_residual = add!(g, residual_ph, o_out)
+
+    # ── MLP ──
+    normed_mlp = rmsnorm!(g, attn_residual, post_norm_w_ph, eps)
+    gu = matmul!(g, w_gu_ph, normed_mlp)
+    gate_out = slice!(g, gu, 1, 0, intermediate)
+    up_out = slice!(g, gu, 1, intermediate, intermediate)
+    swi = silu!(g, gate_out)
+    mlp_hidden = mul!(g, swi, up_out)
+    mlp_out = matmul!(g, w_down_ph, mlp_hidden)
+    out_residual = add!(g, attn_residual, mlp_out)
+
+    # Optionally compute normed output for next layer
+    # Use a dummy norm weight placeholder if needed
+    out_normed = if emit_normed
+        next_norm_w_ph = placeholder!(g, (hidden, 1), Float16)
+        rmsnorm!(g, out_residual, next_norm_w_ph, eps)
+    else
+        out_residual  # placeholder
+    end
+
+    targets = emit_normed ? [out_residual, out_normed] : [out_residual]
+    compiled = compile!(g, targets)
+
+    # Note: if emit_normed, the last placeholder is next_norm_w
+    GraphTransformerLayer(compiled,
+        x_ph, residual_ph, w_qkv_ph, w_o_ph, cos_ph, sin_ph,
+        post_norm_w_ph, w_gu_ph, w_down_ph,
+        out_residual, out_normed, hidden, seq_len)
+end
+
+# ── Multi-layer fused graph ──
+
+struct GraphFullForward
+    compiled::CompiledGraph
+
+    # Per-layer placeholders (indexed by layer)
+    input_norm_ws::Vector{GraphTensor}     # input rmsnorm weights
+    w_qkvs::Vector{GraphTensor}
+    w_os::Vector{GraphTensor}
+    post_norm_ws::Vector{GraphTensor}
+    w_gate_ups::Vector{GraphTensor}
+    w_downs::Vector{GraphTensor}
+
+    # Shared placeholders
+    x_ph::GraphTensor          # initial input (hidden, seq) — embedding output
+    cos_ph::GraphTensor
+    sin_ph::GraphTensor
+    final_norm_w_ph::GraphTensor
+
+    # Outputs
+    out::GraphTensor           # final normed output (hidden, seq)
+
+    n_layers::Int
+    hidden::Int
+    seq_len::Int
+end
+
+"""Build a full N-layer transformer forward pass as a SINGLE MPSGraph.
+Eliminates all per-layer Julia→ObjC dispatch overhead."""
+function build_full_forward(hidden::Int, head_dim::Int, n_q_heads::Int, n_kv_heads::Int,
+                            intermediate::Int, seq_len::Int, n_layers::Int, eps::Float32)
+    g = MetalGraphBuilder()
+    q_dim = n_q_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+    qkv_dim = q_dim + 2 * kv_dim
+    half_hd = head_dim ÷ 2
+    gqa_ratio = n_q_heads ÷ n_kv_heads
+    scale = Float16(1.0 / sqrt(Float64(head_dim)))
+
+    # Shared placeholders
+    x_ph = placeholder!(g, (hidden, seq_len), Float16)
+    cos_ph = placeholder!(g, (half_hd, seq_len), Float16)
+    sin_ph = placeholder!(g, (half_hd, seq_len), Float16)
+    cos_3d = reshape!(g, cos_ph, (half_hd, 1, seq_len))
+    sin_3d = reshape!(g, sin_ph, (half_hd, 1, seq_len))
+
+    # Per-layer placeholders
+    input_norm_ws = GraphTensor[]
+    w_qkvs = GraphTensor[]
+    w_os = GraphTensor[]
+    post_norm_ws = GraphTensor[]
+    w_gate_ups = GraphTensor[]
+    w_downs = GraphTensor[]
+
+    residual = x_ph
+    for layer_idx in 1:n_layers
+        # Layer norm weights
+        in_nw = placeholder!(g, (hidden, 1), Float16)
+        post_nw = placeholder!(g, (hidden, 1), Float16)
+        push!(input_norm_ws, in_nw)
+        push!(post_norm_ws, post_nw)
+
+        # Weight placeholders
+        wqkv = placeholder!(g, (qkv_dim, hidden), Float16)
+        wo = placeholder!(g, (hidden, q_dim), Float16)
+        wgu = placeholder!(g, (2 * intermediate, hidden), Float16)
+        wd = placeholder!(g, (hidden, intermediate), Float16)
+        push!(w_qkvs, wqkv); push!(w_os, wo)
+        push!(w_gate_ups, wgu); push!(w_downs, wd)
+
+        # ── Input RMSNorm ──
+        normed = rmsnorm!(g, residual, in_nw, eps)
+
+        # ── Attention ──
+        qkv = matmul!(g, wqkv, normed)
+        q_flat = slice!(g, qkv, 1, 0, q_dim)
+        k_flat = slice!(g, qkv, 1, q_dim, kv_dim)
+        v_flat = slice!(g, qkv, 1, q_dim + kv_dim, kv_dim)
+
+        q_3d = reshape!(g, q_flat, (head_dim, n_q_heads, seq_len))
+        k_3d = reshape!(g, k_flat, (head_dim, n_kv_heads, seq_len))
+        v_3d = reshape!(g, v_flat, (head_dim, n_kv_heads, seq_len))
+
+        q_roped = apply_rope!(g, q_3d, cos_3d, sin_3d, half_hd)
+        k_roped = apply_rope!(g, k_3d, cos_3d, sin_3d, half_hd)
+
+        # Rearrange for batched matmul
+        q_t = graph_transpose!(g, q_roped, 2, 3)
+        q_t = graph_transpose!(g, q_t, 1, 2)
+        k_t = graph_transpose!(g, k_roped, 2, 3)
+        v_t = graph_transpose!(g, v_3d, 2, 3)
+
+        if gqa_ratio > 1
+            k_exp = expanddims!(g, k_t, 3)
+            k_tiled = concat!(g, [k_exp for _ in 1:gqa_ratio], 3)
+            k_t = reshape!(g, k_tiled, (head_dim, seq_len, n_q_heads))
+            v_exp = expanddims!(g, v_t, 3)
+            v_tiled = concat!(g, [v_exp for _ in 1:gqa_ratio], 3)
+            v_t = reshape!(g, v_tiled, (head_dim, seq_len, n_q_heads))
+        end
+
+        scores = matmul!(g, q_t, k_t)
+        scores = mul!(g, scores, constant_scalar!(g, Float64(scale), Float16))
+
+        ones_mat = constant_fill!(g, 1.0, (seq_len, seq_len), Float16)
+        mask = bandpart!(g, ones_mat, -1, 0)
+        inv_mask = sub!(g, constant_scalar!(g, 1.0, Float16), mask)
+        scores = add!(g, scores, mul!(g, inv_mask, constant_scalar!(g, -1e4, Float16)))
+
+        attn_w = softmax!(g, scores, 1)
+        attn_out = matmul!(g, v_t, attn_w)
+        attn_out = graph_transpose!(g, attn_out, 2, 3)
+        attn_flat = reshape!(g, attn_out, (q_dim, seq_len))
+
+        o_out = matmul!(g, wo, attn_flat)
+        residual = add!(g, residual, o_out)
+
+        # ── MLP ──
+        normed_mlp = rmsnorm!(g, residual, post_nw, eps)
+        gu = matmul!(g, wgu, normed_mlp)
+        gate_out = slice!(g, gu, 1, 0, intermediate)
+        up_out = slice!(g, gu, 1, intermediate, intermediate)
+        mlp_out = matmul!(g, wd, mul!(g, silu!(g, gate_out), up_out))
+        residual = add!(g, residual, mlp_out)
+    end
+
+    # Final norm
+    final_nw = placeholder!(g, (hidden, 1), Float16)
+    final_out = rmsnorm!(g, residual, final_nw, eps)
+
+    compiled = compile!(g, [final_out])
+
+    GraphFullForward(compiled,
+        input_norm_ws, w_qkvs, w_os, post_norm_ws, w_gate_ups, w_downs,
+        x_ph, cos_ph, sin_ph, final_nw, final_out,
+        n_layers, hidden, seq_len)
+end
+
+export GraphMLP, build_mlp_graph, execute_mlp!
+export GraphAttention, build_attention_graph, apply_rope!
+export GraphTransformerLayer, build_transformer_layer
+export GraphFullForward, build_full_forward
+
+end # module

--- a/src/graph_forward.jl
+++ b/src/graph_forward.jl
@@ -638,9 +638,306 @@ function build_full_forward(hidden::Int, head_dim::Int, n_q_heads::Int, n_kv_hea
         n_layers, hidden, seq_len)
 end
 
+# ── Decode graph with KV cache ──
+
+struct GraphDecodeLayer
+    """Single-layer decode graph: takes KV cache as input, outputs layer result + new K/V."""
+    compiled::CompiledGraph
+
+    # Placeholders
+    x_ph::GraphTensor           # input (hidden, 1) — already normed
+    residual_ph::GraphTensor    # residual (hidden, 1)
+    w_qkv_ph::GraphTensor
+    w_o_ph::GraphTensor
+    cos_ph::GraphTensor         # (half_hd, 1) for current position
+    sin_ph::GraphTensor
+    k_cache_ph::GraphTensor     # (head_dim, n_kv, max_len)
+    v_cache_ph::GraphTensor     # (head_dim, n_kv, max_len)
+    attn_mask_ph::GraphTensor   # (1, max_len) — 0 for valid, -1e4 for invalid
+    post_norm_w_ph::GraphTensor
+    w_gate_up_ph::GraphTensor
+    w_down_ph::GraphTensor
+
+    # Outputs
+    out_residual::GraphTensor   # (hidden, 1)
+    new_k::GraphTensor          # (head_dim, n_kv, 1) — to append to cache
+    new_v::GraphTensor          # (head_dim, n_kv, 1)
+
+    max_len::Int
+end
+
+"""Build a decode (seq=1) transformer layer with KV cache attention.
+The KV cache is passed as a placeholder of fixed max_len; a mask hides unused positions."""
+function build_decode_layer(hidden::Int, head_dim::Int, n_q_heads::Int, n_kv_heads::Int,
+                            intermediate::Int, max_len::Int, eps::Float32)
+    g = MetalGraphBuilder()
+    q_dim = n_q_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+    qkv_dim = q_dim + 2 * kv_dim
+    half_hd = head_dim ÷ 2
+    gqa_ratio = n_q_heads ÷ n_kv_heads
+    scale = Float16(1.0 / sqrt(Float64(head_dim)))
+
+    # Placeholders
+    x_ph = placeholder!(g, (hidden, 1), Float16)
+    residual_ph = placeholder!(g, (hidden, 1), Float16)
+    w_qkv_ph = placeholder!(g, (qkv_dim, hidden), Float16)
+    w_o_ph = placeholder!(g, (hidden, q_dim), Float16)
+    cos_ph = placeholder!(g, (half_hd, 1), Float16)
+    sin_ph = placeholder!(g, (half_hd, 1), Float16)
+    k_cache_ph = placeholder!(g, (head_dim, n_kv_heads, max_len), Float16)
+    v_cache_ph = placeholder!(g, (head_dim, n_kv_heads, max_len), Float16)
+    attn_mask_ph = placeholder!(g, (1, max_len), Float16)  # 0 or -1e4
+    post_norm_w_ph = placeholder!(g, (hidden, 1), Float16)
+    w_gu_ph = placeholder!(g, (2 * intermediate, hidden), Float16)
+    w_down_ph = placeholder!(g, (hidden, intermediate), Float16)
+
+    # ── QKV ──
+    qkv = matmul!(g, w_qkv_ph, x_ph)  # (qkv_dim, 1)
+    q_flat = slice!(g, qkv, 1, 0, q_dim)
+    k_flat = slice!(g, qkv, 1, q_dim, kv_dim)
+    v_flat = slice!(g, qkv, 1, q_dim + kv_dim, kv_dim)
+
+    # Reshape to 3D: (head_dim, n_heads, 1)
+    q_3d = reshape!(g, q_flat, (head_dim, n_q_heads, 1))
+    k_3d = reshape!(g, k_flat, (head_dim, n_kv_heads, 1))
+    v_3d = reshape!(g, v_flat, (head_dim, n_kv_heads, 1))
+
+    # RoPE
+    cos_3d = reshape!(g, cos_ph, (half_hd, 1, 1))
+    sin_3d = reshape!(g, sin_ph, (half_hd, 1, 1))
+    q_roped = apply_rope!(g, q_3d, cos_3d, sin_3d, half_hd)
+    k_roped = apply_rope!(g, k_3d, cos_3d, sin_3d, half_hd)
+
+    # New K/V to output (for cache update)
+    new_k = k_roped  # (head_dim, n_kv, 1)
+    new_v = v_3d     # (head_dim, n_kv, 1) — V doesn't get RoPE
+
+    # ── Attention with KV cache ──
+    # K cache: (head_dim, n_kv, max_len) — already includes all past K
+    # For the current step, the caller should have already written new_k into the cache
+    # at the right position. So k_cache_ph is the FULL cache including this step.
+    # (We output new_k/new_v for the caller to update cache BEFORE the next call.)
+
+    # Q: (head_dim, n_q, 1) → need (1, head_dim, n_q) for batched matmul
+    q_t = graph_transpose!(g, q_roped, 2, 3)    # (head_dim, 1, n_q)
+    q_t = graph_transpose!(g, q_t, 1, 2)         # (1, head_dim, n_q)
+
+    # K cache: (head_dim, n_kv, max_len) → (head_dim, max_len, n_kv) for matmul
+    k_t = graph_transpose!(g, k_cache_ph, 2, 3)  # (head_dim, max_len, n_kv)
+
+    # V cache: same rearrangement
+    v_t = graph_transpose!(g, v_cache_ph, 2, 3)  # (head_dim, max_len, n_kv)
+
+    # GQA tiling for K and V
+    if gqa_ratio > 1
+        k_exp = expanddims!(g, k_t, 3)
+        k_tiled = concat!(g, [k_exp for _ in 1:gqa_ratio], 3)
+        k_t = reshape!(g, k_tiled, (head_dim, max_len, n_q_heads))
+
+        v_exp = expanddims!(g, v_t, 3)
+        v_tiled = concat!(g, [v_exp for _ in 1:gqa_ratio], 3)
+        v_t = reshape!(g, v_tiled, (head_dim, max_len, n_q_heads))
+    end
+
+    # Scores: (1, head_dim, n_q) @ (head_dim, max_len, n_q) → (1, max_len, n_q)
+    scores = matmul!(g, q_t, k_t)
+    scores = mul!(g, scores, constant_scalar!(g, Float64(scale), Float16))
+
+    # Apply mask: attn_mask is (1, max_len), broadcast over n_q
+    scores = add!(g, scores, attn_mask_ph)
+
+    # Softmax along dim 2 (the max_len dimension: (1, max_len, n_q) → softmax over max_len)
+    attn_w = softmax!(g, scores, 2)
+
+    # Value aggregation: (head_dim, max_len, n_q) @ (max_len, 1, n_q)
+    # We need attn_w transposed: (1, max_len, n_q) → (max_len, 1, n_q)
+    attn_w_t = graph_transpose!(g, attn_w, 1, 2)  # (max_len, 1, n_q)
+    # Actually: matmul!(v_t, attn_w_t) = (head_dim, max_len, n_q) @ (max_len, 1, n_q) → (head_dim, 1, n_q)
+    attn_out = matmul!(g, v_t, attn_w_t)
+
+    # Reshape back: (head_dim, 1, n_q) → (head_dim, n_q, 1) → (q_dim, 1)
+    attn_out = graph_transpose!(g, attn_out, 2, 3)  # (head_dim, n_q, 1)
+    attn_flat = reshape!(g, attn_out, (q_dim, 1))
+
+    # O projection + residual
+    o_out = matmul!(g, w_o_ph, attn_flat)
+    attn_res = add!(g, residual_ph, o_out)
+
+    # ── MLP ──
+    normed_mlp = rmsnorm!(g, attn_res, post_norm_w_ph, eps)
+    gu = matmul!(g, w_gu_ph, normed_mlp)
+    gate_out = slice!(g, gu, 1, 0, intermediate)
+    up_out = slice!(g, gu, 1, intermediate, intermediate)
+    mlp_out = matmul!(g, w_down_ph, mul!(g, silu!(g, gate_out), up_out))
+    out_residual = add!(g, attn_res, mlp_out)
+
+    compiled = compile!(g, [out_residual, new_k, new_v])
+
+    GraphDecodeLayer(compiled,
+        x_ph, residual_ph, w_qkv_ph, w_o_ph, cos_ph, sin_ph,
+        k_cache_ph, v_cache_ph, attn_mask_ph,
+        post_norm_w_ph, w_gu_ph, w_down_ph,
+        out_residual, new_k, new_v, max_len)
+end
+
+
+# ── Fused multi-layer decode ──
+
+struct GraphDecodeFull
+    """Fused N-layer decode graph with KV cache."""
+    compiled::CompiledGraph
+
+    # Shared
+    x_ph::GraphTensor
+    cos_ph::GraphTensor
+    sin_ph::GraphTensor
+    attn_mask_ph::GraphTensor
+
+    # Per-layer
+    input_norm_ws::Vector{GraphTensor}
+    w_qkvs::Vector{GraphTensor}
+    w_os::Vector{GraphTensor}
+    k_caches::Vector{GraphTensor}
+    v_caches::Vector{GraphTensor}
+    post_norm_ws::Vector{GraphTensor}
+    w_gate_ups::Vector{GraphTensor}
+    w_downs::Vector{GraphTensor}
+
+    # Final norm
+    final_norm_w_ph::GraphTensor
+
+    # Outputs
+    out::GraphTensor
+    new_ks::Vector{GraphTensor}
+    new_vs::Vector{GraphTensor}
+
+    n_layers::Int
+    max_len::Int
+end
+
+"""Build fused N-layer decode graph with KV cache attention."""
+function build_decode_full(hidden::Int, head_dim::Int, n_q_heads::Int, n_kv_heads::Int,
+                           intermediate::Int, max_len::Int, n_layers::Int, eps::Float32)
+    g = MetalGraphBuilder()
+    q_dim = n_q_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+    qkv_dim = q_dim + 2 * kv_dim
+    half_hd = head_dim ÷ 2
+    gqa_ratio = n_q_heads ÷ n_kv_heads
+    scale = Float16(1.0 / sqrt(Float64(head_dim)))
+
+    # Shared placeholders
+    x_ph = placeholder!(g, (hidden, 1), Float16)
+    cos_ph = placeholder!(g, (half_hd, 1), Float16)
+    sin_ph = placeholder!(g, (half_hd, 1), Float16)
+    attn_mask_ph = placeholder!(g, (1, max_len), Float16)
+
+    cos_3d = reshape!(g, cos_ph, (half_hd, 1, 1))
+    sin_3d = reshape!(g, sin_ph, (half_hd, 1, 1))
+
+    input_norm_ws = GraphTensor[]
+    w_qkvs = GraphTensor[]
+    w_os = GraphTensor[]
+    k_caches = GraphTensor[]
+    v_caches = GraphTensor[]
+    post_norm_ws = GraphTensor[]
+    w_gate_ups = GraphTensor[]
+    w_downs = GraphTensor[]
+    new_ks = GraphTensor[]
+    new_vs = GraphTensor[]
+
+    residual = x_ph
+
+    for _ in 1:n_layers
+        in_nw = placeholder!(g, (hidden, 1), Float16)
+        wqkv = placeholder!(g, (qkv_dim, hidden), Float16)
+        wo = placeholder!(g, (hidden, q_dim), Float16)
+        kc = placeholder!(g, (head_dim, n_kv_heads, max_len), Float16)
+        vc = placeholder!(g, (head_dim, n_kv_heads, max_len), Float16)
+        post_nw = placeholder!(g, (hidden, 1), Float16)
+        wgu = placeholder!(g, (2 * intermediate, hidden), Float16)
+        wd = placeholder!(g, (hidden, intermediate), Float16)
+
+        push!(input_norm_ws, in_nw); push!(w_qkvs, wqkv); push!(w_os, wo)
+        push!(k_caches, kc); push!(v_caches, vc)
+        push!(post_norm_ws, post_nw); push!(w_gate_ups, wgu); push!(w_downs, wd)
+
+        # RMSNorm + QKV
+        normed = rmsnorm!(g, residual, in_nw, eps)
+        qkv = matmul!(g, wqkv, normed)
+        q_flat = slice!(g, qkv, 1, 0, q_dim)
+        k_flat = slice!(g, qkv, 1, q_dim, kv_dim)
+        v_flat = slice!(g, qkv, 1, q_dim + kv_dim, kv_dim)
+
+        q_3d = reshape!(g, q_flat, (head_dim, n_q_heads, 1))
+        k_3d = reshape!(g, k_flat, (head_dim, n_kv_heads, 1))
+        v_3d = reshape!(g, v_flat, (head_dim, n_kv_heads, 1))
+
+        q_roped = apply_rope!(g, q_3d, cos_3d, sin_3d, half_hd)
+        k_roped = apply_rope!(g, k_3d, cos_3d, sin_3d, half_hd)
+        push!(new_ks, k_roped)
+        push!(new_vs, v_3d)
+
+        # Attention with KV cache
+        q_t = graph_transpose!(g, q_roped, 2, 3)
+        q_t = graph_transpose!(g, q_t, 1, 2)     # (1, head_dim, n_q)
+        k_t = graph_transpose!(g, kc, 2, 3)       # (head_dim, max_len, n_kv)
+        v_t = graph_transpose!(g, vc, 2, 3)       # (head_dim, max_len, n_kv)
+
+        if gqa_ratio > 1
+            k_exp = expanddims!(g, k_t, 3)
+            k_tiled = concat!(g, [k_exp for _ in 1:gqa_ratio], 3)
+            k_t = reshape!(g, k_tiled, (head_dim, max_len, n_q_heads))
+            v_exp = expanddims!(g, v_t, 3)
+            v_tiled = concat!(g, [v_exp for _ in 1:gqa_ratio], 3)
+            v_t = reshape!(g, v_tiled, (head_dim, max_len, n_q_heads))
+        end
+
+        scores = matmul!(g, q_t, k_t)  # (1, max_len, n_q)
+        scores = mul!(g, scores, constant_scalar!(g, Float64(scale), Float16))
+        scores = add!(g, scores, attn_mask_ph)
+        attn_w = softmax!(g, scores, 2)
+
+        attn_w_t = graph_transpose!(g, attn_w, 1, 2)  # (max_len, 1, n_q)
+        attn_out = matmul!(g, v_t, attn_w_t)           # (head_dim, 1, n_q)
+        attn_out = graph_transpose!(g, attn_out, 2, 3)  # (head_dim, n_q, 1)
+        attn_flat = reshape!(g, attn_out, (q_dim, 1))
+
+        o_out = matmul!(g, wo, attn_flat)
+        residual = add!(g, residual, o_out)
+
+        # MLP
+        normed_mlp = rmsnorm!(g, residual, post_nw, eps)
+        gu = matmul!(g, wgu, normed_mlp)
+        gate_out = slice!(g, gu, 1, 0, intermediate)
+        up_out = slice!(g, gu, 1, intermediate, intermediate)
+        mlp_out = matmul!(g, wd, mul!(g, silu!(g, gate_out), up_out))
+        residual = add!(g, residual, mlp_out)
+    end
+
+    final_nw = placeholder!(g, (hidden, 1), Float16)
+    final_out = rmsnorm!(g, residual, final_nw, eps)
+
+    all_outputs = GraphTensor[final_out]
+    append!(all_outputs, new_ks)
+    append!(all_outputs, new_vs)
+
+    compiled = compile!(g, all_outputs)
+
+    GraphDecodeFull(compiled,
+        x_ph, cos_ph, sin_ph, attn_mask_ph,
+        input_norm_ws, w_qkvs, w_os, k_caches, v_caches,
+        post_norm_ws, w_gate_ups, w_downs,
+        final_nw, final_out, new_ks, new_vs,
+        n_layers, max_len)
+end
+
 export GraphMLP, build_mlp_graph, execute_mlp!
 export GraphAttention, build_attention_graph, apply_rope!
 export GraphTransformerLayer, build_transformer_layer
 export GraphFullForward, build_full_forward
+export GraphDecodeLayer, build_decode_layer
+export GraphDecodeFull, build_decode_full
 
 end # module

--- a/src/metal_graph.jl
+++ b/src/metal_graph.jl
@@ -59,7 +59,10 @@ end
 # ── Graph tensor handle ──
 struct GraphTensor
     ptr::Ptr{Cvoid}  # MPSGraphTensor*
+    shape::Tuple    # Julia-convention shape (col-major)
+    dtype::Type
 end
+GraphTensor(ptr, shape) = GraphTensor(ptr, shape, Float16)  # default
 
 # ── Graph builder ──
 mutable struct MetalGraphBuilder
@@ -79,12 +82,11 @@ internally stored as reversed shape for MPSGraph (row-major)."""
 function placeholder!(g::MetalGraphBuilder, shape, ::Type{T}; name="") where T
     # Reverse shape: Julia col-major (M,N) = MPSGraph row-major (N,M)
     ns = _ns_shape(reverse(shape))
-    nm = name == "" ? C_NULL : _ns_string(name)
     t = ccall(:objc_msgSend, Ptr{Cvoid},
         (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt32, Ptr{Cvoid}),
         g.graph, _sel("placeholderWithShape:dataType:name:"),
         ns, _mps_dtype(T), C_NULL)
-    gt = GraphTensor(t)
+    gt = GraphTensor(t, tuple(shape...), T)
     push!(g.placeholders, gt)
     gt
 end
@@ -94,15 +96,16 @@ function constant!(g::MetalGraphBuilder, shape, ::Type{T}) where T
     placeholder!(g, shape, T)
 end
 
-"""Matrix multiplication: out = a @ b (Julia convention).
-Internally swaps order for MPSGraph row-major: mps_matmul(b, a)."""
+"""Matrix multiplication: out = a @ b (Julia convention)."""
 function matmul!(g::MetalGraphBuilder, a::GraphTensor, b::GraphTensor)
     # Swap: MPSGraph row-major matmul(b, a) = Julia col-major a @ b
     t = ccall(:objc_msgSend, Ptr{Cvoid},
         (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
         g.graph, _sel("matrixMultiplicationWithPrimaryTensor:secondaryTensor:name:"),
         b.ptr, a.ptr, C_NULL)
-    GraphTensor(t)
+    # Output shape: (a.rows, b.cols) in Julia
+    out_shape = (a.shape[1], b.shape[2])
+    GraphTensor(t, out_shape, a.dtype)
 end
 
 """Element-wise addition: out = a + b."""
@@ -111,16 +114,16 @@ function add!(g::MetalGraphBuilder, a::GraphTensor, b::GraphTensor)
         (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
         g.graph, _sel("additionWithPrimaryTensor:secondaryTensor:name:"),
         a.ptr, b.ptr, C_NULL)
-    GraphTensor(t)
+    GraphTensor(t, a.shape, a.dtype)
 end
 
-"""Element-wise multiplication: out = a * b."""
+"""Element-wise multiplication."""
 function mul!(g::MetalGraphBuilder, a::GraphTensor, b::GraphTensor)
     t = ccall(:objc_msgSend, Ptr{Cvoid},
         (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
         g.graph, _sel("multiplicationWithPrimaryTensor:secondaryTensor:name:"),
         a.ptr, b.ptr, C_NULL)
-    GraphTensor(t)
+    GraphTensor(t, a.shape, a.dtype)
 end
 
 """Cast tensor to different type."""
@@ -129,51 +132,69 @@ function cast!(g::MetalGraphBuilder, x::GraphTensor, ::Type{T}) where T
         (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt32, Ptr{Cvoid}),
         g.graph, _sel("castTensor:toType:name:"),
         x.ptr, _mps_dtype(T), C_NULL)
-    GraphTensor(t)
+    GraphTensor(t, x.shape, T)
 end
 
 """Reshape tensor."""
 function reshape!(g::MetalGraphBuilder, x::GraphTensor, shape)
-    ns = _ns_shape(shape)
+    ns = _ns_shape(reverse(shape))
     t = ccall(:objc_msgSend, Ptr{Cvoid},
         (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
         g.graph, _sel("reshapeTensor:withShape:name:"),
         x.ptr, ns, C_NULL)
-    GraphTensor(t)
+    GraphTensor(t, tuple(shape...), x.dtype)
 end
 
-"""Transpose last two dimensions."""
-function transpose!(g::MetalGraphBuilder, x::GraphTensor, dim1::Int, dim2::Int)
+"""Apply SiLU activation: x * sigmoid(x)."""
+function silu!(g::MetalGraphBuilder, x::GraphTensor)
+    # MPSGraph has direct sigmoid + multiplication
+    sig = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        g.graph, _sel("sigmoidWithTensor:name:"), x.ptr, C_NULL)
     t = ccall(:objc_msgSend, Ptr{Cvoid},
-        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt, UInt, Ptr{Cvoid}),
-        g.graph, _sel("transposeTensor:dimension:withDimension:name:"),
-        x.ptr, UInt(dim1), UInt(dim2), C_NULL)
-    GraphTensor(t)
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        g.graph, _sel("multiplicationWithPrimaryTensor:secondaryTensor:name:"),
+        x.ptr, sig, C_NULL)
+    GraphTensor(t, x.shape, x.dtype)
 end
 
 # ── Compiled executable ──
 struct CompiledGraph
     graph::Ptr{Cvoid}
     targets::Vector{GraphTensor}
+    placeholders::Vector{GraphTensor}  # ordered inputs
     queue_ptr::Ptr{Cvoid}
+    executable::Ptr{Cvoid}  # pre-compiled MPSGraphExecutable (or C_NULL for legacy path)
 end
 
-"""Compile graph for repeated execution."""
-function compile!(g::MetalGraphBuilder, targets::Vector{GraphTensor})
+"""Compile graph for repeated execution.
+If `inputs` is provided, pre-compiles to an MPSGraphExecutable for minimal per-run overhead.
+"""
+function compile!(g::MetalGraphBuilder, targets::Vector{GraphTensor};
+                  inputs::Vector{GraphTensor}=g.placeholders)
     qp = reinterpret(Ptr{Cvoid}, Metal.global_queue(Metal.device()).ptr)
-    CompiledGraph(g.graph, targets, qp)
+
+    # Try to pre-compile to MPSGraphExecutable
+    # compileWithDevice:feeds:targetTensors:targetOperations:compilationDescriptor:
+    # feeds is NSDictionary<MPSGraphTensor*, MPSGraphShapedType*>
+    # Since all inputs are placeholders, we can build the feeds dict from their known shapes
+    # But MPSGraphShapedType requires shape info we track in GraphTensor
+
+    # For now, use the simpler runtime path (runWithMTLCommandQueue)
+    # TODO: pre-compile requires tracking shapes in GraphTensor
+    CompiledGraph(g.graph, targets, inputs, qp, C_NULL)
 end
 
-"""Execute graph with feed data. Returns Dict of target → result MtlArray."""
+"""Execute graph with feed data. Returns Dict of target → host Array (copies from GPU)."""
 function execute!(cg::CompiledGraph, feeds::Dict{GraphTensor, <:MtlArray})
     # Build feed dict: MPSGraphTensor → MPSGraphTensorData
     feed_keys = Ptr{Cvoid}[]
     feed_vals = Ptr{Cvoid}[]
-    roots = Any[]  # keep alive
+    roots = Any[]
 
     for (gt, data) in feeds
         push!(roots, data)
-        shape = _ns_shape(reverse(size(data)))  # reverse for row-major
+        shape = _ns_shape(reverse(size(data)))
         buf_ptr = reinterpret(Ptr{Cvoid}, data.data[].ptr)
         td = ccall(:objc_msgSend, Ptr{Cvoid},
             (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt32),
@@ -195,7 +216,6 @@ function execute!(cg::CompiledGraph, feeds::Dict{GraphTensor, <:MtlArray})
         _cls("NSArray"), _sel("arrayWithObjects:count:"),
         pointer(target_ptrs), UInt(length(target_ptrs)))
 
-    # Run
     result_dict = ccall(:objc_msgSend, Ptr{Cvoid},
         (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
         cg.graph, _sel("runWithMTLCommandQueue:feeds:targetTensors:targetOperations:"),
@@ -205,7 +225,6 @@ function execute!(cg::CompiledGraph, feeds::Dict{GraphTensor, <:MtlArray})
         error("MPSGraph execution failed")
     end
 
-    # Extract results
     results = Dict{GraphTensor, Array}()
     for gt in cg.targets
         rtd = ccall(:objc_msgSend, Ptr{Cvoid},
@@ -213,20 +232,18 @@ function execute!(cg::CompiledGraph, feeds::Dict{GraphTensor, <:MtlArray})
             result_dict, _sel("objectForKey:"), gt.ptr)
         nda = _msg(rtd, "mpsndarray")
 
-        # Get shape from NDArray (row-major) and reverse to Julia col-major
         ndims = ccall(:objc_msgSend, UInt, (Ptr{Cvoid}, Ptr{Cvoid}),
             nda, _sel("numberOfDimensions"))
         mps_shape = ntuple(ndims) do i
             Int(ccall(:objc_msgSend, UInt, (Ptr{Cvoid}, Ptr{Cvoid}, UInt),
                 nda, _sel("lengthOfDimension:"), UInt(i - 1)))
         end
-        shape = reverse(mps_shape)  # reverse back to Julia convention
+        shape = reverse(mps_shape)
 
-        # Read data
         n_elements = prod(shape)
-        result = zeros(Float32, n_elements)  # TODO: handle other dtypes
+        result = gt.dtype == Float16 ? zeros(Float16, n_elements) : zeros(Float32, n_elements)
         GC.@preserve result ccall(:objc_msgSend, Cvoid,
-            (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Float32}, Ptr{Cvoid}),
+            (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
             nda, _sel("readBytes:strideBytes:"), pointer(result), C_NULL)
 
         results[gt] = reshape(result, shape)
@@ -235,8 +252,71 @@ function execute!(cg::CompiledGraph, feeds::Dict{GraphTensor, <:MtlArray})
     return results
 end
 
+"""Execute graph and write results to pre-allocated MtlArrays (stays on GPU).
+This is the fast path — avoids host↔device copies.
+"""
+function execute_gpu!(cg::CompiledGraph, feeds::Dict{GraphTensor, <:MtlArray},
+                     outputs::Dict{GraphTensor, <:MtlArray})
+    # Build feeds_array and results_array as NSArrays
+    # runWithMTLCommandQueue:feeds:targetTensors:targetOperations: returns a dict
+    # We then need to copy from result's MTLBuffer to output MtlArrays
+    # OR use encodeToCommandBuffer which writes directly to provided buffers
+
+    feed_keys = Ptr{Cvoid}[]
+    feed_vals = Ptr{Cvoid}[]
+    roots = Any[feeds, outputs]
+
+    for (gt, data) in feeds
+        shape = _ns_shape(reverse(size(data)))
+        buf_ptr = reinterpret(Ptr{Cvoid}, data.data[].ptr)
+        td = ccall(:objc_msgSend, Ptr{Cvoid},
+            (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt32),
+            _msg(_cls("MPSGraphTensorData"), "alloc"),
+            _sel("initWithMTLBuffer:shape:dataType:"),
+            buf_ptr, shape, _mps_dtype(eltype(data)))
+        push!(feed_keys, gt.ptr)
+        push!(feed_vals, td)
+    end
+
+    # Pre-create output TensorDatas wrapping user's MtlArrays
+    results_results_dict = Dict{GraphTensor, Ptr{Cvoid}}()
+    out_keys = Ptr{Cvoid}[]
+    out_vals = Ptr{Cvoid}[]
+    for (gt, data) in outputs
+        shape = _ns_shape(reverse(size(data)))
+        buf_ptr = reinterpret(Ptr{Cvoid}, data.data[].ptr)
+        td = ccall(:objc_msgSend, Ptr{Cvoid},
+            (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt32),
+            _msg(_cls("MPSGraphTensorData"), "alloc"),
+            _sel("initWithMTLBuffer:shape:dataType:"),
+            buf_ptr, shape, _mps_dtype(eltype(data)))
+        push!(out_keys, gt.ptr)
+        push!(out_vals, td)
+    end
+
+    feed_dict = GC.@preserve feed_keys feed_vals ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Ptr{Cvoid}}, Ptr{Ptr{Cvoid}}, UInt),
+        _cls("NSDictionary"), _sel("dictionaryWithObjects:forKeys:count:"),
+        pointer(feed_vals), pointer(feed_keys), UInt(length(feed_keys)))
+
+    results_dict = GC.@preserve out_keys out_vals ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Ptr{Cvoid}}, Ptr{Ptr{Cvoid}}, UInt),
+        _cls("NSDictionary"), _sel("dictionaryWithObjects:forKeys:count:"),
+        pointer(out_vals), pointer(out_keys), UInt(length(out_keys)))
+
+    # Call: -[MPSGraph runWithMTLCommandQueue:feeds:targetOperations:resultsDictionary:]
+    # This writes results directly into the provided MTLBuffers
+    ccall(:objc_msgSend, Cvoid,
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        cg.graph, _sel("runWithMTLCommandQueue:feeds:targetOperations:resultsDictionary:"),
+        cg.queue_ptr, feed_dict, C_NULL, results_dict)
+
+    GC.@preserve roots nothing
+    return outputs
+end
+
 export MetalGraphBuilder, GraphTensor, CompiledGraph
-export placeholder!, constant!, matmul!, add!, mul!, cast!, reshape!, transpose!
-export compile!, execute!
+export placeholder!, matmul!, add!, mul!, cast!, reshape!, silu!
+export compile!, execute!, execute_gpu!
 
 end # module

--- a/src/metal_graph.jl
+++ b/src/metal_graph.jl
@@ -96,15 +96,17 @@ function constant!(g::MetalGraphBuilder, shape, ::Type{T}) where T
     placeholder!(g, shape, T)
 end
 
-"""Matrix multiplication: out = a @ b (Julia convention)."""
+"""Matrix multiplication: out = a @ b (Julia convention).
+Supports batched matmul: (M, K, B...) @ (K, N, B...) → (M, N, B...)."""
 function matmul!(g::MetalGraphBuilder, a::GraphTensor, b::GraphTensor)
     # Swap: MPSGraph row-major matmul(b, a) = Julia col-major a @ b
     t = ccall(:objc_msgSend, Ptr{Cvoid},
         (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
         g.graph, _sel("matrixMultiplicationWithPrimaryTensor:secondaryTensor:name:"),
         b.ptr, a.ptr, C_NULL)
-    # Output shape: (a.rows, b.cols) in Julia
-    out_shape = (a.shape[1], b.shape[2])
+    # Output shape: (a.rows, b.cols, batch_dims...) in Julia
+    batch_dims = length(a.shape) > 2 ? a.shape[3:end] : ()
+    out_shape = (a.shape[1], b.shape[2], batch_dims...)
     GraphTensor(t, out_shape, a.dtype)
 end
 
@@ -143,6 +145,177 @@ function reshape!(g::MetalGraphBuilder, x::GraphTensor, shape)
         g.graph, _sel("reshapeTensor:withShape:name:"),
         x.ptr, ns, C_NULL)
     GraphTensor(t, tuple(shape...), x.dtype)
+end
+
+# ── Axis conversion helper ──
+# Julia dim d in ndims-dimensional tensor → MPSGraph axis (ndims - d)
+_mps_axis(julia_dim::Int, ndims::Int) = Int64(ndims - julia_dim)
+
+"""Element-wise subtraction: out = a - b."""
+function sub!(g::MetalGraphBuilder, a::GraphTensor, b::GraphTensor)
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        g.graph, _sel("subtractionWithPrimaryTensor:secondaryTensor:name:"),
+        a.ptr, b.ptr, C_NULL)
+    GraphTensor(t, a.shape, a.dtype)
+end
+
+"""Element-wise division: out = a / b."""
+function div!(g::MetalGraphBuilder, a::GraphTensor, b::GraphTensor)
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        g.graph, _sel("divisionWithPrimaryTensor:secondaryTensor:name:"),
+        a.ptr, b.ptr, C_NULL)
+    GraphTensor(t, a.shape, a.dtype)
+end
+
+"""Element-wise negation: out = -x."""
+function neg!(g::MetalGraphBuilder, x::GraphTensor)
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        g.graph, _sel("negativeWithTensor:name:"), x.ptr, C_NULL)
+    GraphTensor(t, x.shape, x.dtype)
+end
+
+"""Element-wise square: out = x^2."""
+function square!(g::MetalGraphBuilder, x::GraphTensor)
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        g.graph, _sel("squareWithTensor:name:"), x.ptr, C_NULL)
+    GraphTensor(t, x.shape, x.dtype)
+end
+
+"""Reciprocal square root: out = 1/sqrt(x)."""
+function rsqrt!(g::MetalGraphBuilder, x::GraphTensor)
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        g.graph, _sel("reverseSquareRootWithTensor:name:"), x.ptr, C_NULL)
+    GraphTensor(t, x.shape, x.dtype)
+end
+
+"""Mean reduction along Julia dimension(s)."""
+function mean!(g::MetalGraphBuilder, x::GraphTensor, julia_dims::Vector{Int})
+    nd = length(x.shape)
+    axes_ns = _ns_shape([_mps_axis(d, nd) for d in julia_dims])
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        g.graph, _sel("meanOfTensor:axes:name:"),
+        x.ptr, axes_ns, C_NULL)
+    # Output shape: reduced dims become 1
+    out_shape = ntuple(length(x.shape)) do i
+        i in julia_dims ? 1 : x.shape[i]
+    end
+    GraphTensor(t, out_shape, x.dtype)
+end
+
+"""Create a scalar constant tensor (broadcast-compatible)."""
+function constant_scalar!(g::MetalGraphBuilder, value::Real, ::Type{T}) where T
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Float64, UInt32),
+        g.graph, _sel("constantWithScalar:dataType:"),
+        Float64(value), _mps_dtype(T))
+    GraphTensor(t, (1,), T)
+end
+
+"""Create a constant tensor with specific shape, filled with a scalar value."""
+function constant_fill!(g::MetalGraphBuilder, value::Real, shape, ::Type{T}) where T
+    ns = _ns_shape(reverse(shape))
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Float64, Ptr{Cvoid}, UInt32),
+        g.graph, _sel("constantWithScalar:shape:dataType:"),
+        Float64(value), ns, _mps_dtype(T))
+    GraphTensor(t, tuple(shape...), T)
+end
+
+"""RMS normalization: x / sqrt(mean(x^2, dim=1) + eps) * gamma.
+gamma is a GraphTensor placeholder for the norm weights."""
+function rmsnorm!(g::MetalGraphBuilder, x::GraphTensor, gamma::GraphTensor, eps::Float32)
+    x_sq = square!(g, x)
+    ms = mean!(g, x_sq, [1])  # mean along feature dim
+    eps_t = constant_scalar!(g, eps, x.dtype)
+    ms_eps = add!(g, ms, eps_t)
+    inv = rsqrt!(g, ms_eps)
+    normed = mul!(g, x, inv)
+    mul!(g, normed, gamma)
+end
+
+"""Softmax along Julia dimension."""
+function softmax!(g::MetalGraphBuilder, x::GraphTensor, julia_dim::Int)
+    mps_ax = _mps_axis(julia_dim, length(x.shape))
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Int64, Ptr{Cvoid}),
+        g.graph, _sel("softMaxWithTensor:axis:name:"),
+        x.ptr, mps_ax, C_NULL)
+    GraphTensor(t, x.shape, x.dtype)
+end
+
+"""Slice along a single Julia dimension: out = x[..., start:start+length-1, ...]."""
+function slice!(g::MetalGraphBuilder, x::GraphTensor, julia_dim::Int, start::Int, len::Int)
+    mps_ax = _mps_axis(julia_dim, length(x.shape))
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt, Int64, Int64, Ptr{Cvoid}),
+        g.graph, _sel("sliceTensor:dimension:start:length:name:"),
+        x.ptr, UInt(mps_ax), Int64(start), Int64(len), C_NULL)
+    out_shape = ntuple(length(x.shape)) do i
+        i == julia_dim ? len : x.shape[i]
+    end
+    GraphTensor(t, out_shape, x.dtype)
+end
+
+"""Concatenate tensors along Julia dimension."""
+function concat!(g::MetalGraphBuilder, tensors::Vector{GraphTensor}, julia_dim::Int)
+    mps_ax = _mps_axis(julia_dim, length(tensors[1].shape))
+    ptrs = [t.ptr for t in tensors]
+    ns_arr = GC.@preserve ptrs ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Ptr{Cvoid}}, UInt),
+        _cls("NSArray"), _sel("arrayWithObjects:count:"),
+        pointer(ptrs), UInt(length(ptrs)))
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Int64, Ptr{Cvoid}),
+        g.graph, _sel("concatTensors:dimension:name:"),
+        ns_arr, Int64(mps_ax), C_NULL)
+    total = sum(tensors[i].shape[julia_dim] for i in eachindex(tensors))
+    out_shape = ntuple(length(tensors[1].shape)) do i
+        i == julia_dim ? total : tensors[1].shape[i]
+    end
+    GraphTensor(t, out_shape, tensors[1].dtype)
+end
+
+"""Transpose two Julia dimensions."""
+function graph_transpose!(g::MetalGraphBuilder, x::GraphTensor, dim1::Int, dim2::Int)
+    nd = length(x.shape)
+    mps1 = UInt(_mps_axis(dim1, nd)); mps2 = UInt(_mps_axis(dim2, nd))
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt, UInt, Ptr{Cvoid}),
+        g.graph, _sel("transposeTensor:dimension:withDimension:name:"),
+        x.ptr, mps1, mps2, C_NULL)
+    out_shape = ntuple(nd) do i
+        i == dim1 ? x.shape[dim2] : i == dim2 ? x.shape[dim1] : x.shape[i]
+    end
+    GraphTensor(t, out_shape, x.dtype)
+end
+
+"""Expand dims: insert a size-1 dimension at Julia position."""
+function expanddims!(g::MetalGraphBuilder, x::GraphTensor, julia_dim::Int)
+    nd = length(x.shape) + 1
+    mps_ax = Int64(_mps_axis(julia_dim, nd))
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Int64, Ptr{Cvoid}),
+        g.graph, _sel("expandDimsOfTensor:axis:name:"),
+        x.ptr, mps_ax, C_NULL)
+    new_shape = ntuple(nd) do i
+        i < julia_dim ? x.shape[i] : i == julia_dim ? 1 : x.shape[i-1]
+    end
+    GraphTensor(t, new_shape, x.dtype)
+end
+
+"""Create lower-triangular band matrix for causal masking."""
+function bandpart!(g::MetalGraphBuilder, x::GraphTensor, num_lower::Int, num_upper::Int)
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Int64, Int64, Ptr{Cvoid}),
+        g.graph, _sel("bandPartWithTensor:numLower:numUpper:name:"),
+        x.ptr, Int64(num_lower), Int64(num_upper), C_NULL)
+    GraphTensor(t, x.shape, x.dtype)
 end
 
 """Apply SiLU activation: x * sigmoid(x)."""
@@ -234,11 +407,12 @@ function execute!(cg::CompiledGraph, feeds::Dict{GraphTensor, <:MtlArray})
 
         ndims = ccall(:objc_msgSend, UInt, (Ptr{Cvoid}, Ptr{Cvoid}),
             nda, _sel("numberOfDimensions"))
+        # MPSNDArray reports dimensions in Julia (col-major) order already
         mps_shape = ntuple(ndims) do i
             Int(ccall(:objc_msgSend, UInt, (Ptr{Cvoid}, Ptr{Cvoid}, UInt),
                 nda, _sel("lengthOfDimension:"), UInt(i - 1)))
         end
-        shape = reverse(mps_shape)
+        shape = mps_shape
 
         n_elements = prod(shape)
         result = gt.dtype == Float16 ? zeros(Float16, n_elements) : zeros(Float32, n_elements)
@@ -316,7 +490,10 @@ function execute_gpu!(cg::CompiledGraph, feeds::Dict{GraphTensor, <:MtlArray},
 end
 
 export MetalGraphBuilder, GraphTensor, CompiledGraph
-export placeholder!, matmul!, add!, mul!, cast!, reshape!, silu!
+export placeholder!, constant!, matmul!, add!, sub!, mul!, div!, neg!
+export square!, rsqrt!, mean!, cast!, reshape!, silu!, rmsnorm!
+export softmax!, slice!, concat!, graph_transpose!, expanddims!, bandpart!
+export constant_scalar!, constant_fill!
 export compile!, execute!, execute_gpu!
 
 end # module

--- a/src/metal_graph.jl
+++ b/src/metal_graph.jl
@@ -1,0 +1,242 @@
+"""
+    metal_graph.jl — MPSGraph wrapper for graph-level GPU compilation
+
+Wraps Apple's MPSGraph framework (the engine behind MLX) with a Julia-friendly API.
+Enables graph-level operation fusion, eliminating intermediate memory round-trips.
+
+Usage:
+    g = MetalGraphBuilder()
+    x = placeholder!(g, (3072, 32), Float16)
+    w = constant!(g, weight_matrix)
+    y = matmul!(g, w, x)
+    z = rmsnorm!(g, y, norm_weight, 1f-5)
+    exe = compile!(g, [z])
+    result = execute!(exe, Dict(x => input_data))
+"""
+module MetalGraphModule
+
+using Metal
+using Metal.MTL
+
+# Load MPSGraph framework once
+const _framework_loaded = Ref(false)
+function ensure_framework!()
+    _framework_loaded[] && return
+    OC = Base.loaded_modules[Base.PkgId(
+        Base.UUID("e86c9b32-1129-44ac-8ea0-90d5bb39ded9"), "ObjectiveC")]
+    OC.load_framework("MetalPerformanceShadersGraph")
+    _framework_loaded[] = true
+end
+
+# ObjC helpers
+_sel(n) = ccall(:sel_registerName, Ptr{Cvoid}, (Cstring,), n)
+_cls(n) = ccall(:objc_getClass, Ptr{Cvoid}, (Cstring,), n)
+_msg(o, s) = ccall(:objc_msgSend, Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cvoid}), o, _sel(s))
+_alloc_init(c) = _msg(_msg(_cls(c), "alloc"), "init")
+
+# MPSDataType constants
+const MPSDataTypeFloat16 = UInt32(0x10000010)
+const MPSDataTypeFloat32 = UInt32(0x10000020)
+const MPSDataTypeInt32   = UInt32(0x20000020)
+
+_mps_dtype(::Type{Float16}) = MPSDataTypeFloat16
+_mps_dtype(::Type{Float32}) = MPSDataTypeFloat32
+_mps_dtype(::Type{Int32})   = MPSDataTypeInt32
+
+# Create NSArray of NSNumbers from Julia tuple/vector
+function _ns_shape(dims)
+    nums = map(dims) do d
+        ccall(:objc_msgSend, Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cvoid}, Int64),
+              _cls("NSNumber"), _sel("numberWithLongLong:"), Int64(d))
+    end
+    arr = collect(Ptr{Cvoid}, nums)
+    GC.@preserve arr ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Ptr{Cvoid}}, UInt),
+        _cls("NSArray"), _sel("arrayWithObjects:count:"),
+        pointer(arr), UInt(length(arr)))
+end
+
+# ── Graph tensor handle ──
+struct GraphTensor
+    ptr::Ptr{Cvoid}  # MPSGraphTensor*
+end
+
+# ── Graph builder ──
+mutable struct MetalGraphBuilder
+    graph::Ptr{Cvoid}  # MPSGraph*
+    placeholders::Vector{GraphTensor}
+    constants::Vector{Any}  # keep MtlArrays alive
+
+    function MetalGraphBuilder()
+        ensure_framework!()
+        g = _alloc_init("MPSGraph")
+        new(g, GraphTensor[], Any[])
+    end
+end
+
+"""Create a placeholder input tensor. Shape is Julia (col-major) convention;
+internally stored as reversed shape for MPSGraph (row-major)."""
+function placeholder!(g::MetalGraphBuilder, shape, ::Type{T}; name="") where T
+    # Reverse shape: Julia col-major (M,N) = MPSGraph row-major (N,M)
+    ns = _ns_shape(reverse(shape))
+    nm = name == "" ? C_NULL : _ns_string(name)
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt32, Ptr{Cvoid}),
+        g.graph, _sel("placeholderWithShape:dataType:name:"),
+        ns, _mps_dtype(T), C_NULL)
+    gt = GraphTensor(t)
+    push!(g.placeholders, gt)
+    gt
+end
+
+"""Create a placeholder for constant data (weights). Pass as feed at execution time."""
+function constant!(g::MetalGraphBuilder, shape, ::Type{T}) where T
+    placeholder!(g, shape, T)
+end
+
+"""Matrix multiplication: out = a @ b (Julia convention).
+Internally swaps order for MPSGraph row-major: mps_matmul(b, a)."""
+function matmul!(g::MetalGraphBuilder, a::GraphTensor, b::GraphTensor)
+    # Swap: MPSGraph row-major matmul(b, a) = Julia col-major a @ b
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        g.graph, _sel("matrixMultiplicationWithPrimaryTensor:secondaryTensor:name:"),
+        b.ptr, a.ptr, C_NULL)
+    GraphTensor(t)
+end
+
+"""Element-wise addition: out = a + b."""
+function add!(g::MetalGraphBuilder, a::GraphTensor, b::GraphTensor)
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        g.graph, _sel("additionWithPrimaryTensor:secondaryTensor:name:"),
+        a.ptr, b.ptr, C_NULL)
+    GraphTensor(t)
+end
+
+"""Element-wise multiplication: out = a * b."""
+function mul!(g::MetalGraphBuilder, a::GraphTensor, b::GraphTensor)
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        g.graph, _sel("multiplicationWithPrimaryTensor:secondaryTensor:name:"),
+        a.ptr, b.ptr, C_NULL)
+    GraphTensor(t)
+end
+
+"""Cast tensor to different type."""
+function cast!(g::MetalGraphBuilder, x::GraphTensor, ::Type{T}) where T
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt32, Ptr{Cvoid}),
+        g.graph, _sel("castTensor:toType:name:"),
+        x.ptr, _mps_dtype(T), C_NULL)
+    GraphTensor(t)
+end
+
+"""Reshape tensor."""
+function reshape!(g::MetalGraphBuilder, x::GraphTensor, shape)
+    ns = _ns_shape(shape)
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        g.graph, _sel("reshapeTensor:withShape:name:"),
+        x.ptr, ns, C_NULL)
+    GraphTensor(t)
+end
+
+"""Transpose last two dimensions."""
+function transpose!(g::MetalGraphBuilder, x::GraphTensor, dim1::Int, dim2::Int)
+    t = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt, UInt, Ptr{Cvoid}),
+        g.graph, _sel("transposeTensor:dimension:withDimension:name:"),
+        x.ptr, UInt(dim1), UInt(dim2), C_NULL)
+    GraphTensor(t)
+end
+
+# ── Compiled executable ──
+struct CompiledGraph
+    graph::Ptr{Cvoid}
+    targets::Vector{GraphTensor}
+    queue_ptr::Ptr{Cvoid}
+end
+
+"""Compile graph for repeated execution."""
+function compile!(g::MetalGraphBuilder, targets::Vector{GraphTensor})
+    qp = reinterpret(Ptr{Cvoid}, Metal.global_queue(Metal.device()).ptr)
+    CompiledGraph(g.graph, targets, qp)
+end
+
+"""Execute graph with feed data. Returns Dict of target → result MtlArray."""
+function execute!(cg::CompiledGraph, feeds::Dict{GraphTensor, <:MtlArray})
+    # Build feed dict: MPSGraphTensor → MPSGraphTensorData
+    feed_keys = Ptr{Cvoid}[]
+    feed_vals = Ptr{Cvoid}[]
+    roots = Any[]  # keep alive
+
+    for (gt, data) in feeds
+        push!(roots, data)
+        shape = _ns_shape(reverse(size(data)))  # reverse for row-major
+        buf_ptr = reinterpret(Ptr{Cvoid}, data.data[].ptr)
+        td = ccall(:objc_msgSend, Ptr{Cvoid},
+            (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt32),
+            _msg(_cls("MPSGraphTensorData"), "alloc"),
+            _sel("initWithMTLBuffer:shape:dataType:"),
+            buf_ptr, shape, _mps_dtype(eltype(data)))
+        push!(feed_keys, gt.ptr)
+        push!(feed_vals, td)
+    end
+
+    feed_dict = GC.@preserve feed_keys feed_vals ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Ptr{Cvoid}}, Ptr{Ptr{Cvoid}}, UInt),
+        _cls("NSDictionary"), _sel("dictionaryWithObjects:forKeys:count:"),
+        pointer(feed_vals), pointer(feed_keys), UInt(length(feed_keys)))
+
+    target_ptrs = [t.ptr for t in cg.targets]
+    target_arr = GC.@preserve target_ptrs ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Ptr{Cvoid}}, UInt),
+        _cls("NSArray"), _sel("arrayWithObjects:count:"),
+        pointer(target_ptrs), UInt(length(target_ptrs)))
+
+    # Run
+    result_dict = ccall(:objc_msgSend, Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        cg.graph, _sel("runWithMTLCommandQueue:feeds:targetTensors:targetOperations:"),
+        cg.queue_ptr, feed_dict, target_arr, C_NULL)
+
+    if result_dict == C_NULL
+        error("MPSGraph execution failed")
+    end
+
+    # Extract results
+    results = Dict{GraphTensor, Array}()
+    for gt in cg.targets
+        rtd = ccall(:objc_msgSend, Ptr{Cvoid},
+            (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+            result_dict, _sel("objectForKey:"), gt.ptr)
+        nda = _msg(rtd, "mpsndarray")
+
+        # Get shape from NDArray (row-major) and reverse to Julia col-major
+        ndims = ccall(:objc_msgSend, UInt, (Ptr{Cvoid}, Ptr{Cvoid}),
+            nda, _sel("numberOfDimensions"))
+        mps_shape = ntuple(ndims) do i
+            Int(ccall(:objc_msgSend, UInt, (Ptr{Cvoid}, Ptr{Cvoid}, UInt),
+                nda, _sel("lengthOfDimension:"), UInt(i - 1)))
+        end
+        shape = reverse(mps_shape)  # reverse back to Julia convention
+
+        # Read data
+        n_elements = prod(shape)
+        result = zeros(Float32, n_elements)  # TODO: handle other dtypes
+        GC.@preserve result ccall(:objc_msgSend, Cvoid,
+            (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Float32}, Ptr{Cvoid}),
+            nda, _sel("readBytes:strideBytes:"), pointer(result), C_NULL)
+
+        results[gt] = reshape(result, shape)
+    end
+
+    return results
+end
+
+export MetalGraphBuilder, GraphTensor, CompiledGraph
+export placeholder!, constant!, matmul!, add!, mul!, cast!, reshape!, transpose!
+export compile!, execute!
+
+end # module

--- a/src/mpsgraph_exploration.jl
+++ b/src/mpsgraph_exploration.jl
@@ -1,0 +1,51 @@
+"""
+    mpsgraph_exploration.jl — MPSGraph accessibility from Julia
+
+MPSGraph (MetalPerformanceShadersGraph) is Apple's graph-level computation
+framework — the same engine MLX uses for fused GPU operations. It provides:
+- Graph-level operation fusion (matmul + add + activation in one kernel)
+- Optimized memory management (no intermediate buffers)
+- Hardware-specific optimization (uses Metal's GPU scheduler)
+
+## Discovery
+
+All MPSGraph classes and methods are accessible from Julia via ObjectiveC.jl
+(a dependency of Metal.jl):
+
+```julia
+OC = Base.loaded_modules[Base.PkgId(
+    Base.UUID("e86c9b32-1129-44ac-8ea0-90d5bb39ded9"), "ObjectiveC")]
+OC.load_framework("MetalPerformanceShadersGraph")
+
+# Create graph
+graph = ccall(:objc_msgSend, Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cvoid}),
+    ccall(:objc_msgSend, Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cvoid}),
+        ccall(:objc_getClass, Ptr{Cvoid}, (Cstring,), "MPSGraph"),
+        ccall(:sel_registerName, Ptr{Cvoid}, (Cstring,), "alloc")),
+    ccall(:sel_registerName, Ptr{Cvoid}, (Cstring,), "init"))
+```
+
+## Available methods (verified):
+- `placeholderWithShape:dataType:name:` — create input tensors
+- `matrixMultiplicationWithPrimaryTensor:secondaryTensor:name:` — matmul
+- `rmsNormalizationWithTensor:axes:gamma:epsilon:name:` — rmsnorm
+- `runWithMTLCommandQueue:feeds:targetTensors:targetOperations:` — execute
+- `compileWithDevice:feeds:targetTensors:targetOperations:compilationDescriptor:` — pre-compile
+
+## Approach for LLM inference
+
+Build the entire transformer forward pass as an MPSGraph:
+1. Create placeholder tensors for input tokens, KV cache, weights
+2. Build the computation graph: embed → (rmsnorm → QKV → rope → attn → O → add →
+   rmsnorm → gate_up → swiglu → down → add) × N_layers → rmsnorm → lm_head
+3. Compile once with `compileWithDevice:`
+4. Execute per-token with `runWithMTLCommandQueue:`
+
+This would give us MLX-level performance since it's the same underlying framework.
+
+## Complexity
+
+High — requires wrapping all MPSGraph operations with proper ObjectiveC bindings.
+The ObjectiveC API is verbose (many selector calls) but straightforward.
+Could start with just the matmul + rmsnorm path as a proof of concept.
+"""

--- a/test/test_graph_layer.jl
+++ b/test/test_graph_layer.jl
@@ -1,0 +1,180 @@
+"""Test full MPSGraph transformer layer against CPU reference."""
+
+using Metal
+using Test
+using LinearAlgebra
+
+include(joinpath(@__DIR__, "..", "src", "metal_graph.jl"))
+include(joinpath(@__DIR__, "..", "src", "graph_forward.jl"))
+using .MetalGraphModule
+using .GraphForward
+
+# ── CPU reference implementations ──
+
+function cpu_rmsnorm(x::Matrix{Float32}, w::Vector{Float32}, eps::Float32)
+    ms = sum(x .^ 2, dims=1) ./ size(x, 1)
+    inv = 1.0f0 ./ sqrt.(ms .+ eps)
+    x .* inv .* w
+end
+
+function cpu_rope(x::Array{Float32, 3}, cos_t::Matrix{Float32}, sin_t::Matrix{Float32})
+    hd, nh, seq = size(x)
+    half = hd ÷ 2
+    out = similar(x)
+    for s in 1:seq, h in 1:nh
+        for d in 1:half
+            lo = x[d, h, s]; hi = x[half+d, h, s]
+            c = cos_t[d, s]; sn = sin_t[d, s]
+            out[d, h, s] = lo * c - hi * sn
+            out[half+d, h, s] = hi * c + lo * sn
+        end
+    end
+    out
+end
+
+function cpu_attention(q::Array{Float32,3}, k::Array{Float32,3}, v::Array{Float32,3},
+                       scale::Float32, n_q::Int, n_kv::Int)
+    hd, _, seq = size(q)
+    gqa = n_q ÷ n_kv
+    out = zeros(Float32, hd, n_q, seq)
+
+    for qh in 1:n_q
+        kvh = (qh - 1) ÷ gqa + 1
+        # scores: seq × seq
+        scores = zeros(Float32, seq, seq)
+        for i in 1:seq, j in 1:seq
+            for d in 1:hd
+                scores[j, i] += q[d, qh, i] * k[d, kvh, j]
+            end
+            scores[j, i] *= scale
+        end
+        # Causal mask
+        for i in 1:seq, j in 1:seq
+            if j > i; scores[j, i] = -1f4; end
+        end
+        # Softmax along dim 1 (j dimension)
+        for i in 1:seq
+            mx = maximum(scores[:, i])
+            scores[:, i] .= exp.(scores[:, i] .- mx)
+            scores[:, i] ./= sum(scores[:, i])
+        end
+        # Value aggregation
+        for i in 1:seq, d in 1:hd
+            for j in 1:seq
+                out[d, qh, i] += v[d, kvh, j] * scores[j, i]
+            end
+        end
+    end
+    out
+end
+
+function cpu_transformer_layer(x_normed, residual, w_qkv, w_o, cos_t, sin_t,
+                                post_norm_w, w_gu, w_down, config)
+    hidden = config.hidden; hd = config.head_dim
+    n_q = config.n_q; n_kv = config.n_kv; inter = config.intermediate
+    eps = config.eps; scale = config.scale
+    q_dim = n_q * hd; kv_dim = n_kv * hd
+    seq = size(x_normed, 2)
+
+    # QKV
+    qkv = w_qkv * x_normed
+    q_flat = qkv[1:q_dim, :]
+    k_flat = qkv[q_dim+1:q_dim+kv_dim, :]
+    v_flat = qkv[q_dim+kv_dim+1:q_dim+2*kv_dim, :]
+
+    q_3d = reshape(q_flat, hd, n_q, seq)
+    k_3d = reshape(k_flat, hd, n_kv, seq)
+    v_3d = reshape(v_flat, hd, n_kv, seq)
+
+    # RoPE
+    q_roped = cpu_rope(q_3d, cos_t, sin_t)
+    k_roped = cpu_rope(k_3d, cos_t, sin_t)
+
+    # Attention
+    attn_out = cpu_attention(q_roped, k_roped, v_3d, scale, n_q, n_kv)
+    attn_flat = reshape(attn_out, q_dim, seq)
+
+    # O proj + residual
+    o_out = w_o * attn_flat
+    attn_res = residual .+ o_out
+
+    # Post-attention norm + MLP
+    normed_mlp = cpu_rmsnorm(attn_res, post_norm_w, eps)
+    gu = w_gu * normed_mlp
+    gate = gu[1:inter, :]
+    up = gu[inter+1:2*inter, :]
+    swi = gate .* (1 ./ (1 .+ exp.(-gate)))
+    mlp_out = w_down * (swi .* up)
+
+    out_res = attn_res .+ mlp_out
+    return out_res
+end
+
+# ── Test ──
+
+function test_transformer_layer()
+    # Use small dims for testing
+    hidden = 256; head_dim = 64; n_q = 4; n_kv = 2; intermediate = 512
+    seq_len = 8; eps = 1f-5
+    gqa = n_q ÷ n_kv
+    q_dim = n_q * head_dim; kv_dim = n_kv * head_dim
+    qkv_dim = q_dim + 2 * kv_dim
+    half_hd = head_dim ÷ 2
+    scale = Float32(1.0 / sqrt(Float64(head_dim)))
+
+    config = (hidden=hidden, head_dim=head_dim, n_q=n_q, n_kv=n_kv,
+              intermediate=intermediate, eps=eps, scale=scale)
+
+    # Random data (Float32 for CPU ref, Float16 for GPU)
+    x_normed_f32 = randn(Float32, hidden, seq_len) * 0.1f0
+    residual_f32 = randn(Float32, hidden, seq_len) * 0.1f0
+    w_qkv_f32 = randn(Float32, qkv_dim, hidden) * Float32(0.02)
+    w_o_f32 = randn(Float32, hidden, q_dim) * Float32(0.02)
+    cos_f32 = cos.(randn(Float32, half_hd, seq_len))
+    sin_f32 = sin.(randn(Float32, half_hd, seq_len))
+    post_norm_w_f32 = ones(Float32, hidden)
+    w_gu_f32 = randn(Float32, 2*intermediate, hidden) * Float32(0.02)
+    w_down_f32 = randn(Float32, hidden, intermediate) * Float32(0.02)
+
+    # CPU reference
+    ref = cpu_transformer_layer(x_normed_f32, residual_f32, w_qkv_f32, w_o_f32,
+                                cos_f32, sin_f32, post_norm_w_f32, w_gu_f32, w_down_f32, config)
+
+    # GPU graph
+    println("Building transformer layer graph...")
+    layer = build_transformer_layer(hidden, head_dim, n_q, n_kv, intermediate,
+                                     seq_len, eps; emit_normed=false)
+
+    # Execute
+    feeds = Dict{GraphTensor, MtlArray}(
+        layer.x_ph => MtlArray(Float16.(x_normed_f32)),
+        layer.residual_ph => MtlArray(Float16.(residual_f32)),
+        layer.w_qkv_ph => MtlArray(Float16.(w_qkv_f32)),
+        layer.w_o_ph => MtlArray(Float16.(w_o_f32)),
+        layer.cos_ph => MtlArray(Float16.(cos_f32)),
+        layer.sin_ph => MtlArray(Float16.(sin_f32)),
+        layer.post_norm_w_ph => MtlArray(Float16.(reshape(post_norm_w_f32, hidden, 1))),
+        layer.w_gate_up_ph => MtlArray(Float16.(w_gu_f32)),
+        layer.w_down_ph => MtlArray(Float16.(w_down_f32)),
+    )
+
+    println("Executing graph...")
+    result = execute!(layer.compiled, feeds)
+
+    gpu_out = result[layer.out_residual]
+    ref16 = Float16.(ref)
+
+    @testset "transformer layer" begin
+        @test size(gpu_out) == size(ref16)
+
+        # Per-element relative error
+        err = maximum(abs.(Float32.(gpu_out) .- Float32.(ref16))) /
+              (maximum(abs.(Float32.(ref16))) + 1f-8)
+        println("  Max relative error: $(round(err, digits=5))")
+        @test err < 0.1  # FP16 through full layer will accumulate error
+    end
+end
+
+println("Testing full transformer layer graph...")
+test_transformer_layer()
+println("\nTransformer layer test complete!")

--- a/test/test_graph_ops.jl
+++ b/test/test_graph_ops.jl
@@ -1,0 +1,244 @@
+"""Test MPSGraph ops against CPU references."""
+
+using Metal
+using Test
+
+# Load our module
+include(joinpath(@__DIR__, "..", "src", "metal_graph.jl"))
+using .MetalGraphModule
+
+function test_rmsnorm()
+    @testset "rmsnorm" begin
+        M, N = 128, 16
+        x_data = randn(Float16, M, N)
+        gamma_data = rand(Float16, M) .+ Float16(0.5)
+
+        # CPU reference
+        x32 = Float32.(x_data)
+        ms = sum(x32 .^ 2, dims=1) ./ M
+        inv = 1.0f0 ./ sqrt.(ms .+ 1f-5)
+        ref = Float16.(x32 .* inv .* Float32.(gamma_data))
+
+        # MPSGraph
+        g = MetalGraphBuilder()
+        x = placeholder!(g, (M, N), Float16)
+        gam = placeholder!(g, (M, 1), Float16)
+        out = rmsnorm!(g, x, gam, 1f-5)
+        cg = compile!(g, [out])
+
+        x_gpu = MtlArray(x_data)
+        gam_gpu = MtlArray(reshape(gamma_data, M, 1))
+        result = execute!(cg, Dict(x => x_gpu, gam => gam_gpu))
+
+        gpu_out = result[out]
+        @test size(gpu_out) == (M, N)
+        err = maximum(abs.(Float32.(gpu_out) .- Float32.(ref))) / maximum(abs.(Float32.(ref)))
+        @test err < 0.02  # FP16 tolerance
+        println("  rmsnorm: max relative error = $(round(err, digits=6))")
+    end
+end
+
+function test_softmax()
+    @testset "softmax" begin
+        M, N = 64, 32
+        x_data = randn(Float16, M, N)
+
+        # CPU reference: softmax along dim 1
+        x32 = Float32.(x_data)
+        mx = maximum(x32, dims=1)
+        ex = exp.(x32 .- mx)
+        ref = Float16.(ex ./ sum(ex, dims=1))
+
+        # MPSGraph
+        g = MetalGraphBuilder()
+        x = placeholder!(g, (M, N), Float16)
+        out = softmax!(g, x, 1)
+        cg = compile!(g, [out])
+
+        result = execute!(cg, Dict(x => MtlArray(x_data)))
+        gpu_out = result[out]
+        err = maximum(abs.(Float32.(gpu_out) .- Float32.(ref)))
+        @test err < 0.01
+        println("  softmax dim=1: max abs error = $(round(err, digits=6))")
+
+        # softmax along dim 2
+        mx2 = maximum(x32, dims=2)
+        ex2 = exp.(x32 .- mx2)
+        ref2 = Float16.(ex2 ./ sum(ex2, dims=2))
+
+        g2 = MetalGraphBuilder()
+        x2 = placeholder!(g2, (M, N), Float16)
+        out2 = softmax!(g2, x2, 2)
+        cg2 = compile!(g2, [out2])
+        result2 = execute!(cg2, Dict(x2 => MtlArray(x_data)))
+        gpu_out2 = result2[out2]
+        err2 = maximum(abs.(Float32.(gpu_out2) .- Float32.(ref2)))
+        @test err2 < 0.01
+        println("  softmax dim=2: max abs error = $(round(err2, digits=6))")
+    end
+end
+
+function test_slice_concat()
+    @testset "slice + concat" begin
+        M, N = 128, 16
+        x_data = randn(Float16, M, N)
+
+        # Slice along dim 1: first half and second half
+        half = M ÷ 2
+
+        g = MetalGraphBuilder()
+        x = placeholder!(g, (M, N), Float16)
+        lo = slice!(g, x, 1, 0, half)    # MPSGraph uses 0-based start
+        hi = slice!(g, x, 1, half, half)
+        # Concat back
+        rejoined = concat!(g, [lo, hi], 1)
+        cg = compile!(g, [lo, hi, rejoined])
+
+        result = execute!(cg, Dict(x => MtlArray(x_data)))
+        @test result[lo] ≈ x_data[1:half, :]
+        @test result[hi] ≈ x_data[half+1:end, :]
+        @test result[rejoined] ≈ x_data
+        println("  slice+concat dim=1: passed")
+
+        # Slice along dim 2
+        g2 = MetalGraphBuilder()
+        x2 = placeholder!(g2, (M, N), Float16)
+        s1 = slice!(g2, x2, 2, 0, 8)
+        s2 = slice!(g2, x2, 2, 8, 8)
+        r2 = concat!(g2, [s1, s2], 2)
+        cg2 = compile!(g2, [s1, s2, r2])
+        result2 = execute!(cg2, Dict(x2 => MtlArray(x_data)))
+        @test result2[s1] ≈ x_data[:, 1:8]
+        @test result2[s2] ≈ x_data[:, 9:16]
+        @test result2[r2] ≈ x_data
+        println("  slice+concat dim=2: passed")
+    end
+end
+
+function test_transpose()
+    @testset "transpose" begin
+        D, H, S = 16, 8, 4
+        x_data = randn(Float16, D, H, S)
+
+        # Transpose dims 1 and 2: (D,H,S) → (H,D,S)
+        g = MetalGraphBuilder()
+        x = placeholder!(g, (D, H, S), Float16)
+        out = graph_transpose!(g, x, 1, 2)
+        cg = compile!(g, [out])
+        result = execute!(cg, Dict(x => MtlArray(x_data)))
+        @test size(result[out]) == (H, D, S)
+        @test result[out] ≈ permutedims(x_data, (2, 1, 3))
+        println("  transpose (1,2) on 3D: passed")
+
+        # Transpose dims 2 and 3: (D,H,S) → (D,S,H)
+        g2 = MetalGraphBuilder()
+        x2 = placeholder!(g2, (D, H, S), Float16)
+        out2 = graph_transpose!(g2, x2, 2, 3)
+        cg2 = compile!(g2, [out2])
+        result2 = execute!(cg2, Dict(x2 => MtlArray(x_data)))
+        @test size(result2[out2]) == (D, S, H)
+        @test result2[out2] ≈ permutedims(x_data, (1, 3, 2))
+        println("  transpose (2,3) on 3D: passed")
+    end
+end
+
+function test_rope()
+    @testset "rope (graph ops)" begin
+        hd, seq = 128, 16
+        half = hd ÷ 2
+
+        x_data = randn(Float16, hd, seq)
+        cos_data = rand(Float16, half, seq)
+        sin_data = rand(Float16, half, seq)
+
+        # CPU reference: interleaved rope
+        # x_lo = x[1:half, :], x_hi = x[half+1:end, :]
+        # out_lo = x_lo * cos - x_hi * sin
+        # out_hi = x_hi * cos + x_lo * sin
+        x32 = Float32.(x_data)
+        c32 = Float32.(cos_data); s32 = Float32.(sin_data)
+        ref_lo = x32[1:half, :] .* c32 .- x32[half+1:end, :] .* s32
+        ref_hi = x32[half+1:end, :] .* c32 .+ x32[1:half, :] .* s32
+        ref = Float16.(vcat(ref_lo, ref_hi))
+
+        # MPSGraph
+        g = MetalGraphBuilder()
+        x = placeholder!(g, (hd, seq), Float16)
+        cos_t = placeholder!(g, (half, seq), Float16)
+        sin_t = placeholder!(g, (half, seq), Float16)
+
+        x_lo = slice!(g, x, 1, 0, half)
+        x_hi = slice!(g, x, 1, half, half)
+
+        # out_lo = x_lo * cos - x_hi * sin
+        out_lo = sub!(g, mul!(g, x_lo, cos_t), mul!(g, x_hi, sin_t))
+        # out_hi = x_hi * cos + x_lo * sin
+        out_hi = add!(g, mul!(g, x_hi, cos_t), mul!(g, x_lo, sin_t))
+        out = concat!(g, [out_lo, out_hi], 1)
+
+        cg = compile!(g, [out])
+        result = execute!(cg, Dict(
+            x => MtlArray(x_data),
+            cos_t => MtlArray(cos_data),
+            sin_t => MtlArray(sin_data),
+        ))
+
+        gpu_out = result[out]
+        err = maximum(abs.(Float32.(gpu_out) .- Float32.(ref))) / maximum(abs.(Float32.(ref)))
+        @test err < 0.01
+        println("  rope: max relative error = $(round(err, digits=6))")
+    end
+end
+
+function test_matmul_chain()
+    @testset "matmul chain (MLP-like)" begin
+        D, I, N = 128, 256, 16
+        x_data = randn(Float16, D, N)
+        w_gate = randn(Float16, I, D)
+        w_up = randn(Float16, I, D)
+        w_down = randn(Float16, D, I)
+
+        # CPU reference: down(silu(gate(x)) * up(x))
+        x32 = Float32.(x_data)
+        gate_out = Float32.(w_gate) * x32
+        up_out = Float32.(w_up) * x32
+        silu_gate = gate_out .* (1 ./ (1 .+ exp.(-gate_out)))
+        mlp_out = Float16.(Float32.(w_down) * Float32.(silu_gate .* up_out))
+
+        # MPSGraph: fused gate+up, slice, silu, mul, down
+        g = MetalGraphBuilder()
+        x = placeholder!(g, (D, N), Float16)
+        wg = placeholder!(g, (I, D), Float16)
+        wu = placeholder!(g, (I, D), Float16)
+        wd = placeholder!(g, (D, I), Float16)
+
+        gate = matmul!(g, wg, x)
+        up = matmul!(g, wu, x)
+        swi = silu!(g, gate)
+        fused = mul!(g, swi, up)
+        out = matmul!(g, wd, fused)
+
+        cg = compile!(g, [out])
+        result = execute!(cg, Dict(
+            x => MtlArray(x_data),
+            wg => MtlArray(w_gate),
+            wu => MtlArray(w_up),
+            wd => MtlArray(w_down),
+        ))
+
+        gpu_out = result[out]
+        err = maximum(abs.(Float32.(gpu_out) .- Float32.(mlp_out))) / (maximum(abs.(Float32.(mlp_out))) + 1f-8)
+        @test err < 0.05  # longer chain accumulates FP16 error
+        println("  MLP chain: max relative error = $(round(err, digits=4))")
+    end
+end
+
+# Run all tests
+println("Testing MPSGraph ops...")
+test_rmsnorm()
+test_softmax()
+test_slice_concat()
+test_transpose()
+test_rope()
+test_matmul_chain()
+println("\nAll MPSGraph op tests passed!")


### PR DESCRIPTION
## Summary
- Built complete transformer forward pass (attention + MLP + RMSNorm + RoPE) as a single fused MPSGraph, using Apple's graph compilation engine (same backend as MLX) accessed from Julia via ObjectiveC.jl
- Added full MPSGraph op library: matmul, rmsnorm (from primitives), softmax, slice, concat, transpose, RoPE, GQA tiling, causal masking, SiLU
- Fused 28-layer prefill graph eliminates per-layer dispatch overhead
- Decode graph with KV cache support (padded max-length + mask approach)

Closes #15

### Benchmark results (Llama-3.2-3B dims, FP16, M3 Max)

**Prefill (28 layers):**

| seq | MPSGraph | MLX | Speedup |
|-----|----------|-----|---------|
| 8 | 19.9ms (401 tok/s) | 43.8ms (183 tok/s) | **2.20x** |
| 32 | 31.4ms (1019 tok/s) | 53.2ms (601 tok/s) | **1.69x** |
| 64 | 43.3ms (1480 tok/s) | 54.1ms (1182 tok/s) | **1.25x** |

**Decode (B=1, 28 layers):**

| | MPSGraph | MLX | Speedup |
|-|----------|-----|---------|
| tok/s | 47 (21ms) | 29 (34ms) | **1.6x** |

## Test plan
- [x] `test/test_graph_ops.jl` — validates each MPSGraph op (rmsnorm, softmax, slice, concat, transpose, rope, MLP chain) against CPU reference
- [x] `test/test_graph_layer.jl` — validates full transformer layer graph against CPU reference (0.07% relative error)
- [x] Benchmarks: `scripts/bench_graph_layer.jl`, `scripts/bench_graph_fused.jl`, `scripts/bench_graph_decode.jl`
- [x] MLX comparison: `scripts/bench_mlx_layer.py`

### Follow-up issues
- #20 — Integrate with model loading and generation
- #21 — Quantized weights in MPSGraph
- #22 — MPSGraphExecutable pre-compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)